### PR TITLE
use admin_email and admin_name defined in shop settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,13 @@
 Changelog
 =========
 
-dev
----
+0.5dev
+------
 
-- Use admin_name and admin_email defined in Shop Settings for sending
-  notifications.
-  [fRiSi]
+- Introduce ``INotificationSettings`` which provides ``admin_name`` and
+  ``admin_email`` attributes. Use these settings for sending notifications.
+  [fRiSi, rnix]
+
 
 0.4
 ---

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '0.4'
+version = '0.5dev'
 shortdesc = "Orders persistence and backoffice UI for bda.plone.shop"
 longdesc = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 longdesc += open(os.path.join(os.path.dirname(__file__), 'CHANGES.rst')).read()

--- a/src/bda/plone/orders/interfaces.py
+++ b/src/bda/plone/orders/interfaces.py
@@ -36,6 +36,15 @@ class IVendor(IDiscountSettingsEnabled):
     """
 
 
+class INotificationSettings(Interface):
+    """Interface for looking up mail notification settings.
+    """
+
+    admin_email = Attribute(u"Shop admin email address")
+
+    admin_name = Attribute(u"Shop admin name")
+
+
 class IItemNotificationText(Interface):
     """Interface for providing buyable item order notification text.
     """


### PR DESCRIPTION
and default to siteadmin name for upgraded sites with empty admin name.

requires https://github.com/bluedynamics/bda.plone.shop/pull/26

btw: what about keeping versions/tags in sync between shop components. so it's easier for integrators to know which versions of which packages work together?
