### PR TITLE
Notification when items are getting out of stock.

### DIFF
--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -356,7 +356,6 @@ class OrderCheckoutAdapter(CheckoutAdapter):
 
         items_out_of_stock = list()
         items_out_of_stock_limit = get_shop_article_settings().default_item_minimum_stock
-        print items_out_of_stock_limit
 
         for booking in bookings:
             bookings_soup.add(booking)
@@ -380,7 +379,6 @@ class OrderCheckoutAdapter(CheckoutAdapter):
 
     def create_bookings(self, order):
         ret = list()
-        items_out_of_stock = list()
 
         cart_data = get_data_provider(self.context)
         for uid, count, comment in self.items:

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -355,14 +355,17 @@ class OrderCheckoutAdapter(CheckoutAdapter):
         bookings_soup = get_bookings_soup(self.context)
 
         items_out_of_stock = list()
-        items_out_of_stock_limit = get_shop_article_settings().default_item_minimum_stock
 
         for booking in bookings:
             bookings_soup.add(booking)
 
-            # Item is getting out of stock
-            if items_out_of_stock_limit:
-                if booking.attrs['remaining_stock_available'] <= items_out_of_stock_limit:
+            buyable = get_object_by_uid(self.context, booking.attrs['buyable_uid'])
+            item_stock = get_item_stock(buyable)
+            item_out_of_stock_limit = item_stock.minimum_stock
+
+            if item_out_of_stock_limit:
+                if booking.attrs['remaining_stock_available'] <= item_out_of_stock_limit:
+                    # Item is getting out of stock
                     items_out_of_stock.append(booking.attrs)
         
         if items_out_of_stock:

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -354,26 +354,26 @@ class OrderCheckoutAdapter(CheckoutAdapter):
         # add bookings
         bookings_soup = get_bookings_soup(self.context)
 
-        items_out_of_stock = list()
+        items_stock_threshold_reached = list()
 
         for booking in bookings:
             bookings_soup.add(booking)
 
             buyable = get_object_by_uid(self.context, booking.attrs['buyable_uid'])
             item_stock = get_item_stock(buyable)
-            item_out_of_stock_limit = item_stock.minimum_stock
+            stock_warning_threshold = item_stock.stock_warning_threshold
 
-            if item_out_of_stock_limit:
-                if booking.attrs['remaining_stock_available'] <= item_out_of_stock_limit:
+            if stock_warning_threshold:
+                if booking.attrs['remaining_stock_available'] <= stock_warning_threshold:
                     # Item is getting out of stock
-                    items_out_of_stock.append(booking.attrs)
+                    items_stock_threshold_reached.append(booking.attrs)
         
-        if items_out_of_stock:
-            event = events.ItemOutOfStockEvent(
+        if items_stock_threshold_reached:
+            event = events.StockThresholdReached(
                 self.context,
                 self.request,
                 order.attrs['uid'],
-                items_out_of_stock,
+                items_stock_threshold_reached,
             )
             notify(event)
 

--- a/src/bda/plone/orders/configure.zcml
+++ b/src/bda/plone/orders/configure.zcml
@@ -89,6 +89,11 @@
     for="bda.plone.orders.interfaces.IBookingCancelledEvent"
     handler=".mailnotify.dispatch_notify_booking_cancelled"/>
 
+  <!-- event subscribers item is getting out of stock -->
+  <subscriber
+    for="bda.plone.orders.interfaces.IItemOutOfStockEvent"
+    handler=".mailnotify.dispatch_notify_item_out_of_stock"/>
+
   <!-- create contact on checkout success and save it in soup catalog-->
   <subscriber
     for="bda.plone.checkout.interfaces.ICheckoutDone"

--- a/src/bda/plone/orders/configure.zcml
+++ b/src/bda/plone/orders/configure.zcml
@@ -91,8 +91,8 @@
 
   <!-- event subscribers item is getting out of stock -->
   <subscriber
-    for="bda.plone.orders.interfaces.IItemOutOfStockEvent"
-    handler=".mailnotify.dispatch_notify_item_out_of_stock"/>
+    for="bda.plone.orders.interfaces.IStockThresholdReached"
+    handler=".mailnotify.dispatch_notify_stock_threshold_reached"/>
 
   <!-- create contact on checkout success and save it in soup catalog-->
   <subscriber

--- a/src/bda/plone/orders/events.py
+++ b/src/bda/plone/orders/events.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from bda.plone.orders.interfaces import IBookingCancelledEvent
-from bda.plone.orders.interfaces import IItemOutOfStockEvent
+from bda.plone.orders.interfaces import IStockThresholdReached
 from zope.interface import implementer
 
 
@@ -13,11 +13,11 @@ class BookingCancelledEvent(object):
         self.order_uid = order_uid
         self.booking_attrs = booking_attrs
 
-@implementer(IItemOutOfStockEvent)
-class ItemOutOfStockEvent(object):
+@implementer(IStockThresholdReached)
+class StockThresholdReached(object):
     
-    def __init__(self, context, request, order_uid, items_out_of_stock):
+    def __init__(self, context, request, order_uid, items_stock_threshold_reached):
         self.context = context
         self.request = request
         self.order_uid = order_uid
-        self.items_out_of_stock = items_out_of_stock
+        self.items_stock_threshold_reached = items_stock_threshold_reached

--- a/src/bda/plone/orders/events.py
+++ b/src/bda/plone/orders/events.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from bda.plone.orders.interfaces import IBookingCancelledEvent
+from bda.plone.orders.interfaces import IItemOutOfStockEvent
 from zope.interface import implementer
 
 
@@ -11,3 +12,12 @@ class BookingCancelledEvent(object):
         self.request = request
         self.order_uid = order_uid
         self.booking_attrs = booking_attrs
+
+@implementer(IItemOutOfStockEvent)
+class ItemOutOfStockEvent(object):
+    
+    def __init__(self, context, request, order_uid, items_out_of_stock):
+        self.context = context
+        self.request = request
+        self.order_uid = order_uid
+        self.items_out_of_stock = items_out_of_stock

--- a/src/bda/plone/orders/interfaces.py
+++ b/src/bda/plone/orders/interfaces.py
@@ -136,7 +136,7 @@ class IBookingCancelledEvent(Interface):
     booking_attrs = Attribute(u"Dict of attributes of the cancelled booking.")
 
 
-class IItemOutOfStockEvent(Interface):
+class IStockThresholdReached(Interface):
     """Checkout related event.
     """
     context = Attribute(u"Context in which this event was triggered.")
@@ -145,6 +145,6 @@ class IItemOutOfStockEvent(Interface):
 
     order_uid = Attribute(u"UUID of Order")
 
-    items_out_of_stock = Attribute(u"List of items that are out of stock.")
+    items_stock_threshold_reached = Attribute(u"List of items that are getting out of stock.")
 
 

--- a/src/bda/plone/orders/interfaces.py
+++ b/src/bda/plone/orders/interfaces.py
@@ -134,3 +134,17 @@ class IBookingCancelledEvent(Interface):
     order_uid = Attribute(u"UUID of Order")
 
     booking_attrs = Attribute(u"Dict of attributes of the cancelled booking.")
+
+
+class IItemOutOfStockEvent(Interface):
+    """Checkout related event.
+    """
+    context = Attribute(u"Context in which this event was triggered.")
+
+    request = Attribute(u"Current request.")
+
+    order_uid = Attribute(u"UUID of Order")
+
+    items_out_of_stock = Attribute(u"List of items that are out of stock.")
+
+

--- a/src/bda/plone/orders/mailnotify.py
+++ b/src/bda/plone/orders/mailnotify.py
@@ -454,9 +454,9 @@ class ItemsOutOfStockCB(object):
         for item_attrs in items:
             title = item_attrs['title']
             remaining_stock = item_attrs['remaining_stock_available']
-            item_out_of_stock_text += "%s (Remaining stock: %s)\n" %(title, remaining_stock)
+            items_out_of_stock_text += "%s (Remaining stock: %s)\n" %(title, remaining_stock)
 
-        return item_out_of_stock_text
+        return items_out_of_stock_text
 
 
 def notify_item_out_of_stock(event, who=None):

--- a/src/bda/plone/orders/mailnotify.py
+++ b/src/bda/plone/orders/mailnotify.py
@@ -55,6 +55,7 @@ def dispatch_notify_booking_cancelled(event):
     for func in NOTIFICATIONS['booking_cancelled']:
         func(event)
 
+
 def dispatch_notify_item_out_of_stock(event):
     for func in NOTIFICATIONS['item_out_of_stock']:
         func(event)
@@ -432,7 +433,7 @@ def notify_booking_cancelled(event, who=None):
     order_data = OrderData(event.context, uid=get_order_uid(event))
     templates = dict()
     templates.update(get_booking_cancelled_templates(event.context))
-    templates['booking_cancelled_title_cb'] = ItemOutOfStockTitleCB(event)
+    templates['booking_cancelled_title_cb'] = BookingCancelledTitleCB(event)
     if who == "customer":
         do_notify_customer(event.context, order_data, templates)
     elif who == 'shopmanager':
@@ -453,7 +454,7 @@ class ItemsOutOfStockCB(object):
         for item_attrs in items:
             title = item_attrs['title']
             remaining_stock = item_attrs['remaining_stock_available']
-            item_out_of_stock_text = "%s (Remaining stock: %s)\n" %(title, remaining_stock)
+            item_out_of_stock_text += "%s (Remaining stock: %s)\n" %(title, remaining_stock)
 
         return item_out_of_stock_text
 

--- a/src/bda/plone/orders/mailnotify.py
+++ b/src/bda/plone/orders/mailnotify.py
@@ -2,6 +2,7 @@
 from Products.CMFPlone.utils import safe_unicode
 from bda.plone.cart import ascur
 from bda.plone.cart import get_catalog_brain
+from bda.plone.cart import get_object_by_uid
 from bda.plone.checkout.interfaces import ICheckoutEvent
 from bda.plone.checkout.interfaces import ICheckoutSettings
 from bda.plone.orders import interfaces as ifaces
@@ -11,6 +12,7 @@ from bda.plone.orders import vocabularies as vocabs
 from bda.plone.orders.common import DT_FORMAT
 from bda.plone.orders.common import OrderData
 from bda.plone.orders.interfaces import IBookingCancelledEvent
+from bda.plone.orders.interfaces import IItemOutOfStockEvent
 from bda.plone.orders.interfaces import IGlobalNotificationText
 from bda.plone.orders.interfaces import IItemNotificationText
 from bda.plone.orders.interfaces import INotificationSettings
@@ -18,6 +20,7 @@ from bda.plone.orders.interfaces import IPaymentText
 from bda.plone.orders.mailtemplates import get_booking_cancelled_templates
 from bda.plone.orders.mailtemplates import get_order_templates
 from bda.plone.orders.mailtemplates import get_reservation_templates
+from bda.plone.orders.mailtemplates import get_item_out_of_stock_templates
 from bda.plone.payment.interfaces import IPaymentEvent
 from email.utils import formataddr
 from plone import api
@@ -34,6 +37,7 @@ NOTIFICATIONS = {
     'checkout_success': [],
     'payment_success': [],
     'booking_cancelled': [],
+    'item_out_of_stock': []
 }
 
 
@@ -49,6 +53,10 @@ def dispatch_notify_payment_success(event):
 
 def dispatch_notify_booking_cancelled(event):
     for func in NOTIFICATIONS['booking_cancelled']:
+        func(event)
+
+def dispatch_notify_item_out_of_stock(event):
+    for func in NOTIFICATIONS['item_out_of_stock']:
         func(event)
 
 
@@ -296,6 +304,7 @@ POSSIBLE_TEMPLATE_CALLBACKS = [
     'item_listing',
     'order_summary',
     'payment_text',
+    'items_out_of_stock'
 ]
 
 
@@ -378,6 +387,8 @@ def get_order_uid(event):
         return event.order_uid
     if IBookingCancelledEvent.providedBy(event):
         return event.order_uid
+    if IItemOutOfStockEvent.providedBy(event):
+        return event.order_uid
 
 
 def notify_order_success(event, who=None):
@@ -415,17 +426,47 @@ class BookingCancelledTitleCB(object):
     def __call__(self, *args):
         return self.event.booking_attrs['eventtitle']
 
-
 def notify_booking_cancelled(event, who=None):
     """Send notification mail after booking was cancelled.
     """
     order_data = OrderData(event.context, uid=get_order_uid(event))
     templates = dict()
     templates.update(get_booking_cancelled_templates(event.context))
-    templates['booking_cancelled_title_cb'] = BookingCancelledTitleCB(event)
+    templates['booking_cancelled_title_cb'] = ItemOutOfStockTitleCB(event)
     if who == "customer":
         do_notify_customer(event.context, order_data, templates)
     elif who == 'shopmanager':
+        do_notify_shopmanager(event.context, order_data, templates)
+    else:
+        raise ValueError(
+            'kw "who" mus be one out of ("customer", "shopmanager")'
+        )
+
+class ItemsOutOfStockCB(object):
+
+    def __init__(self, event):
+        self.event = event
+
+    def __call__(self, *args):
+        items_out_of_stock_text = ""
+        items = self.event.items_out_of_stock
+        for item_attrs in items:
+            title = item_attrs['title']
+            remaining_stock = item_attrs['remaining_stock_available']
+            item_out_of_stock_text = "%s (Remaining stock: %s)\n" %(title, remaining_stock)
+
+        return item_out_of_stock_text
+
+
+def notify_item_out_of_stock(event, who=None):
+    """Send notification mail when item is getting out of stock.
+    """
+    order_data = OrderData(event.context, uid=get_order_uid(event))
+    templates = dict()
+    templates.update(get_item_out_of_stock_templates(event.context))
+    templates['items_out_of_stock_cb'] = ItemsOutOfStockCB(event)
+
+    if who == 'shopmanager':
         do_notify_shopmanager(event.context, order_data, templates)
     else:
         raise ValueError(
@@ -481,3 +522,11 @@ def notify_booking_cancelled_shopmanager(event):
 
 NOTIFICATIONS['booking_cancelled'].append(notify_booking_cancelled_customer)
 NOTIFICATIONS['booking_cancelled'].append(notify_booking_cancelled_shopmanager)
+
+
+def notify_item_out_of_stock_shopmanager(event):
+    notify_item_out_of_stock(event, who="shopmanager")
+
+NOTIFICATIONS['item_out_of_stock'].append(notify_item_out_of_stock_shopmanager)
+
+

--- a/src/bda/plone/orders/mailnotify.py
+++ b/src/bda/plone/orders/mailnotify.py
@@ -459,7 +459,7 @@ class StockThresholdReachedCB(object):
         return items_stock_threshold_reached_text
 
 
-def notify_stock_threshold_reached(event, who=None):
+def notify_stock_threshold_reached(event):
     """Send notification mail when item is getting out of stock.
     """
     order_data = OrderData(event.context, uid=get_order_uid(event))
@@ -467,12 +467,8 @@ def notify_stock_threshold_reached(event, who=None):
     templates.update(get_stock_threshold_reached_templates(event.context))
     templates['items_stock_threshold_reached_text_cb'] = StockThresholdReachedCB(event)
 
-    if who == 'shopmanager':
-        do_notify_shopmanager(event.context, order_data, templates)
-    else:
-        raise ValueError(
-            'kw "who" mus be one out of ("customer", "shopmanager")'
-        )
+    do_notify_shopmanager(event.context, order_data, templates)
+    
 
 
 # below here we have the actual events
@@ -524,10 +520,6 @@ def notify_booking_cancelled_shopmanager(event):
 NOTIFICATIONS['booking_cancelled'].append(notify_booking_cancelled_customer)
 NOTIFICATIONS['booking_cancelled'].append(notify_booking_cancelled_shopmanager)
 
-
-def notify_stock_threshold_reached_shopmanager(event):
-    notify_stock_threshold_reached(event, who="shopmanager")
-
-NOTIFICATIONS['stock_threshold_reached'].append(notify_stock_threshold_reached_shopmanager)
+NOTIFICATIONS['stock_threshold_reached'].append(notify_stock_threshold_reached)
 
 

--- a/src/bda/plone/orders/mailtemplates.py
+++ b/src/bda/plone/orders/mailtemplates.py
@@ -97,6 +97,17 @@ Cancelled item: %(booking_cancelled_title)s
 Order details: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 """
 
+ITEM_OUT_OF_STOCK_SUBJECT_EN = u"Order %s has products that are getting out of stock."
+
+ITEM_OUT_OF_STOCK_BODY_EN = """
+Date: %(date)s
+
+Products getting out of stock:
+%(items_out_of_stock)s
+
+"""
+
+
 ###############################################################################
 # de
 ###############################################################################
@@ -519,6 +530,13 @@ CANCELLED_BOOKING_TEMPLATES = {
         'body': CANCELLED_BOOKING_BODY_NO}
 }
 
+ITEM_OUT_OF_STOCK_TEMPLATES = {
+    'en': {
+        'subject': ITEM_OUT_OF_STOCK_SUBJECT_EN,
+        'body': ITEM_OUT_OF_STOCK_BODY_EN
+    }
+}
+
 
 def _get_templates(context, TPL, default='en'):
     lang = context.restrictedTraverse('@@plone_portal_state').language()
@@ -535,6 +553,10 @@ def get_reservation_templates(context):
 
 def get_booking_cancelled_templates(context):
     return _get_templates(context, CANCELLED_BOOKING_TEMPLATES)
+
+
+def get_item_out_of_stock_templates(context):
+    return _get_templates(context, ITEM_OUT_OF_STOCK_TEMPLATES)
 
 
 # list of template attributes which are required. by default, no attributes are

--- a/src/bda/plone/orders/mailtemplates.py
+++ b/src/bda/plone/orders/mailtemplates.py
@@ -97,13 +97,13 @@ Cancelled item: %(booking_cancelled_title)s
 Order details: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 """
 
-ITEM_OUT_OF_STOCK_SUBJECT_EN = u"Order %s has products that are getting out of stock."
+STOCK_THRESHOLD_REACHED_SUBJECT_EN = u"Order %s has products that are getting out of stock."
 
-ITEM_OUT_OF_STOCK_BODY_EN = """
+STOCK_THRESHOLD_REACHED_BODY_EN = """
 Date: %(date)s
 
 Products getting out of stock:
-%(items_out_of_stock)s
+%(items_stock_threshold_reached_text)s
 
 """
 
@@ -530,10 +530,10 @@ CANCELLED_BOOKING_TEMPLATES = {
         'body': CANCELLED_BOOKING_BODY_NO}
 }
 
-ITEM_OUT_OF_STOCK_TEMPLATES = {
+STOCK_THRESHOLD_REACHED_TEMPLATES = {
     'en': {
-        'subject': ITEM_OUT_OF_STOCK_SUBJECT_EN,
-        'body': ITEM_OUT_OF_STOCK_BODY_EN
+        'subject': STOCK_THRESHOLD_REACHED_SUBJECT_EN,
+        'body': STOCK_THRESHOLD_REACHED_BODY_EN
     }
 }
 
@@ -555,8 +555,8 @@ def get_booking_cancelled_templates(context):
     return _get_templates(context, CANCELLED_BOOKING_TEMPLATES)
 
 
-def get_item_out_of_stock_templates(context):
-    return _get_templates(context, ITEM_OUT_OF_STOCK_TEMPLATES)
+def get_stock_threshold_reached_templates(context):
+    return _get_templates(context, STOCK_THRESHOLD_REACHED_TEMPLATES)
 
 
 # list of template attributes which are required. by default, no attributes are


### PR DESCRIPTION
Use case:
* Webshop administrator doesn't notice that items are getting out of stock. 

What was implemented:
* Notification dispatcher: "dispatch_notify_item_out_of_stock"
* Notification event interface: IItemOutOfStockEvent - Includes list of items that are getting out of stock.
* Mail template with list of items in the current order that are getting out of stock.
* Template callback to build list of items out of stock text: ItemsOutOfStockCB

When does the notification is triggered:
* When the order is created and the stock is decreased: https://github.com/bluedynamics/bda.plone.orders/pull/31/commits/fa0dbdcb013c6814356b097901b94ceada1e4ff8#diff-52126ce69c755f7a6d9a58ac1d77f216R369
* Notification is only sent if remaining stock is less or equal than the limit set in the Article settings. See https://github.com/bluedynamics/bda.plone.shop/pull/63

Todos:
* Create translations for notification template.