### PR TITLE
More mail notification, transition and general bugfixes/optimizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 0.10.dev0
 ---------
 
+- Reimplement ``update_item_stock`` according to transition changes, documented at the table in ``transitions.py``.
+  [thet]
+
 - If no ``uid`` was given when calling the ``@@order`` view, redirect to current context and show an error message instead of failing.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 0.10.dev0
 ---------
 
+- Make the current context as base url for ``ajaxurl`` in OrdersTable and BookingsTable.
+  This way, the current subsites settings are respected, e.g. when rendering state transition dropdowns, which again sends mails and those need the correct sender.
+  [thet]
+
 - Reimplement ``update_item_stock`` according to transition changes, documented at the table in ``transitions.py``.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 0.10.dev0
 ---------
 
+- In mail templates, list reserved items seperately from normal ordered items.
+  [thet]
+
 - Fix modifications of ``buyable_comment`` in ``@@orders`` view not being saved.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 0.10.dev0
 ---------
 
+- In ``@@bookings`` view, group by buyable per default.
+  [thet]
+
+- In ``@@bookings`` view, add ``buyable_comment`` column and combine first name, last name and address information to save space.
+  [thet]
+
 - Don't include reserved bookings in ``OrderData`` payment information (net, vat) and don't count them when calculating the salaried state for orders.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 0.10.dev0
 ---------
 
+- If no ``uid`` was given when calling the ``@@order`` view, redirect to current context and show an error message instead of failing.
+  [thet]
+
 - In ``@@bookings`` view, group by buyable per default.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 0.10.dev0
 ---------
 
+- Create safe filenames for ``@@exportorders_contextual``.
+  [thet]
+
 - Make the current context as base url for ``ajaxurl`` in OrdersTable and BookingsTable.
   This way, the current subsites settings are respected, e.g. when rendering state transition dropdowns, which again sends mails and those need the correct sender.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 0.10.dev0
 ---------
 
+- Don't include reserved bookings in ``OrderData`` payment information (net, vat) and don't count them when calculating the salaried state for orders.
+  [thet]
+
 - In mail templates, list reserved items seperately from normal ordered items.
   [thet]
 

--- a/src/bda/plone/orders/__init__.py
+++ b/src/bda/plone/orders/__init__.py
@@ -4,6 +4,7 @@ from zope.i18nmessageid import MessageFactory
 
 import gettext
 import pycountry
+import unicodedata
 
 
 message_factory = MessageFactory('bda.plone.orders')
@@ -13,7 +14,23 @@ def safe_encode(string):
     """Safely unicode objects to UTF-8. If it's a binary string, just return
     it.
     """
-    return safe_unicode(string).encode('utf-8')
+    if isinstance(string, basestring):
+        return safe_unicode(string).encode('utf-8')
+    return string
+
+
+def safe_filename(value):
+    """
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces to hyphens.
+    Remove characters that aren't alphanumerics, underscores, or hyphens.
+    Convert to lowercase. Also strip leading and trailing whitespace.
+
+    Ideas from:
+    https://github.com/django/django/blob/master/django/utils/text.py
+    """
+    value = safe_unicode(value)
+    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+    return value.replace(' ', '-').strip()
 
 
 def get_country_name(country_code, lang='en'):

--- a/src/bda/plone/orders/browser/bookings.py
+++ b/src/bda/plone/orders/browser/bookings.py
@@ -370,8 +370,10 @@ class BookingsTable(BrowserView):
 
     @property
     def ajaxurl(self):
-        site = plone.api.portal.get()
-        return '%s/%s' % (site.absolute_url(), self.data_view_name)
+        return u'{0}/{1}'.format(
+            self.context.absolute_url(),
+            self.data_view_name
+        )
 
     @property
     def columns(self):

--- a/src/bda/plone/orders/browser/bookings.py
+++ b/src/bda/plone/orders/browser/bookings.py
@@ -233,7 +233,7 @@ class BookingsTable(BrowserView):
         group_selector = factory(
             'div:label:select',
             name='group_by',
-            value=self.request.form.get('group_by', ''),
+            value=self.request.form.get('group_by', 'buyable'),
             props={
                 'div.class': 'group_filter',
                 'vocabulary': groups,
@@ -333,6 +333,41 @@ class BookingsTable(BrowserView):
             value = currency + u' {0:.2f}'.format(value)
             return value
 
+    def render_name(self, colname, record):
+        firstname = safe_unicode(self._get_ordervalue(
+            'personal_data.firstname',
+            record,
+        ))
+        lastname = safe_unicode(self._get_ordervalue(
+            'personal_data.lastname',
+            record,
+        ))
+        return u"{0}, {1}".format(firstname, lastname)
+
+    def render_address(self, colname, record):
+        street = safe_unicode(self._get_ordervalue(
+            'billing_address.street',
+            record,
+        ))
+        city   = safe_unicode(self._get_ordervalue(
+            'billing_address.city',
+            record,
+        ))
+        phone  = safe_unicode(self._get_ordervalue(
+            'billing_address.phone',
+            record,
+        ))
+        email  = safe_unicode(record.attrs.get('email', ''))
+
+        return u"{0} {1}<br/>{2}: {3}<br/>{4}: {5}".format(
+            street,
+            city,
+            _("phone", default=u"Phone"),
+            phone,
+            _("email", default=u"Email"),
+            email
+        )
+
     @property
     def ajaxurl(self):
         site = plone.api.portal.get()
@@ -370,28 +405,23 @@ class BookingsTable(BrowserView):
                 'origin': 'b',
             },
             {
-                'id': 'personal_data.lastname',
-                'label': _('lastname', default=u'Last Name'),
+                'id': 'buyable_comment',
+                'label': _('booking_comment', default=u'Comment'),
+                'origin': 'b',
+            },
+            {
+                'id': 'name',
+                'label': u'{0}, {1}'.format(
+                    _('firstname', default=u'First Name'),
+                    _('lastname', default=u'Last Name')
+                ),
+                'renderer': self.render_name,
                 'origin': 'o',
             },
             {
-                'id': 'personal_data.firstname',
-                'label': _('firstname', default=u'First Name'),
-                'origin': 'o',
-            },
-            {
-                'id': 'billing_address.street',
-                'label': _('street', default=u'Street'),
-                'origin': 'o',
-            },
-            {
-                'id': 'billing_address.city',
-                'label': _('city', default=u'City'),
-                'origin': 'o',
-            },
-            {
-                'id': 'personal_data.phone',
-                'label': _('phone', default=u'Phone'),
+                'id': 'address',
+                'label': _('address', default=u'Address'),
+                'renderer': self.render_address,
                 'origin': 'o',
             },
             {

--- a/src/bda/plone/orders/browser/bookings.py
+++ b/src/bda/plone/orders/browser/bookings.py
@@ -354,7 +354,7 @@ class BookingsTable(BrowserView):
             record,
         ))
         phone  = safe_unicode(self._get_ordervalue(
-            'billing_address.phone',
+            'personal_data.phone',
             record,
         ))
         email  = safe_unicode(record.attrs.get('email', ''))

--- a/src/bda/plone/orders/browser/export.py
+++ b/src/bda/plone/orders/browser/export.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_parent
 from AccessControl import Unauthorized
 from Products.CMFPlone.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from StringIO import StringIO
@@ -9,6 +11,7 @@ from bda.plone.cart import get_object_by_uid
 from bda.plone.orders import message_factory as _
 from bda.plone.orders import permissions
 from bda.plone.orders import safe_encode
+from bda.plone.orders import safe_filename
 from bda.plone.orders.browser.views import customers_form_vocab
 from bda.plone.orders.browser.views import vendors_form_vocab
 from bda.plone.orders.common import DT_FORMAT
@@ -261,13 +264,21 @@ class ExportOrdersContextual(BrowserView):
         if not user.checkPermission(permissions.ModifyOrders, self.context):
             raise Unauthorized
 
-        filename = u'{}_{}.csv'.format(
-            safe_encode(self.context.title),
-            datetime.datetime.now().strftime('%Y-%m-%d_%H-%M'))
+        # Special case for constructed objects like IEventOccurrence from
+        # plone.app.event
+        title = self.context.title or aq_parent(self.context).title
+
+        filename = u'{0}_{1}.csv'.format(
+            safe_unicode(title),
+            safe_unicode(datetime.datetime.now().strftime('%Y-%m-%d_%H-%M'))
+        )
+        filename = safe_filename(filename)
         resp = self.request.response
         resp.setHeader('content-type', 'text/csv; charset=utf-8')
         resp.setHeader(
-            'content-disposition', u'attachment;filename={}'.format(filename))
+            'content-disposition',
+            'attachment;filename={}'.format(filename)
+        )
         return self.get_csv()
 
     def export_val(self, record, attr_name):
@@ -307,7 +318,7 @@ class ExportOrdersContextual(BrowserView):
 
         all_orders = {}
         for booking in bookings_soup.query(query_b):
-            booking_attrs = list()
+            booking_attrs = []
             # booking export attrs
             for attr_name in BOOKING_EXPORT_ATTRS:
                 val = self.export_val(booking, attr_name)
@@ -326,7 +337,7 @@ class ExportOrdersContextual(BrowserView):
                 order_data = OrderData(context,
                                        order=order,
                                        vendor_uids=vendor_uids)
-                order_attrs = list()
+                order_attrs = []
                 # order export attrs
                 for attr_name in ORDER_EXPORT_ATTRS:
                     val = self.export_val(order, attr_name)

--- a/src/bda/plone/orders/browser/resources/orders.js
+++ b/src/bda/plone/orders/browser/resources/orders.js
@@ -284,7 +284,7 @@
                 "columnDefs": [
                     {
                         'visible': false,
-                        'targets': [0, 1, 13, 14]
+                        'targets': [0, 1, 11, 12]  // hide Email, buyable_uid, bookings_quantity, bookings_total_sum
                     }
                 ],
 
@@ -317,24 +317,24 @@
                         api.column(0, {page: 'current'}).data().each(function (group, i) {
                             if (last !== group) {
                                 $(rows).eq(i).before(
-                                        '<tr class="group_email"><td colspan="13">' + group + '</td></tr>'
+                                        '<tr class="group_email"><td colspan="10">' + group + '</td></tr>'
                                 );
                                 last = group;
                             }
                         });
-                        api.column(4).visible(true);
+                        api.column(4).visible(true);  // column 4 = item title
                     }
                     // only show email info if grouped by buyable
                     if ($('#input-group_by').val() === 'buyable') {
                         api.column(1, {page: 'current'}).data().each(function (group, i) {
                             if (last !== group) {
                                 $(rows).eq(i).before(
-                                        '<tr class="group_buyable"><td colspan="13">' + group + '</td></tr>'
+                                        '<tr class="group_buyable"><td colspan="10">' + group + '</td></tr>'
                                 );
                                 last = group;
                             }
                         });
-                        api.column(4).visible(false);
+                        api.column(4).visible(false);  // column 4 = item title
                     }
                     $(this).bdajax();
                 }

--- a/src/bda/plone/orders/browser/table.pt
+++ b/src/bda/plone/orders/browser/table.pt
@@ -28,7 +28,7 @@
 
     <tbody>
       <tr>
-        <td tal:attributes="columnspan: python:len(columns)"
+        <td tal:attributes="colspan python:len(columns)"
             i18n:translate="loading_please_wait">
           Loading Data, please wait...
         </td>

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -305,8 +305,10 @@ class OrdersTableBase(BrowserView):
 
     @property
     def ajaxurl(self):
-        site = plone.api.portal.get()
-        return '%s/%s' % (site.absolute_url(), self.data_view_name)
+        return u'{0}/{1}'.format(
+            self.context.absolute_url(),
+            self.data_view_name
+        )
 
     @property
     def columns(self):

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -1,43 +1,45 @@
 # -*- coding: utf-8 -*-
 from AccessControl import Unauthorized
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.statusmessages.interfaces import IStatusMessage
 from bda.plone.cart import ascur
 from bda.plone.cart import get_object_by_uid
 from bda.plone.checkout import message_factory as _co
 from bda.plone.checkout.vocabularies import get_pycountry_name
 from bda.plone.orders import interfaces as ifaces
 from bda.plone.orders import message_factory as _
-from bda.plone.orders import permissions
 from bda.plone.orders import vocabularies as vocabs
+from bda.plone.orders import permissions
 from bda.plone.orders.browser.dropdown import BaseDropdown
-from bda.plone.orders.common import DT_FORMAT
-from bda.plone.orders.common import OrderData
-from bda.plone.orders.common import BookingData
 from bda.plone.orders.common import booking_update_comment
+from bda.plone.orders.common import BookingData
+from bda.plone.orders.common import DT_FORMAT
 from bda.plone.orders.common import get_orders_soup
 from bda.plone.orders.common import get_vendor_by_uid
 from bda.plone.orders.common import get_vendor_uids_for
 from bda.plone.orders.common import get_vendors_for
+from bda.plone.orders.common import OrderData
 from bda.plone.orders.interfaces import IBuyable
 from bda.plone.orders.transitions import do_transition_for
 from bda.plone.orders.transitions import transitions_of_main_state
 from bda.plone.orders.transitions import transitions_of_salaried_state
 from plone.memoize import view
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.statusmessages.interfaces import IStatusMessage
 from repoze.catalog.query import Any
 from repoze.catalog.query import Contains
 from repoze.catalog.query import Eq
-from souper.soup import LazyRecord
 from souper.soup import get_soup
+from souper.soup import LazyRecord
 from yafowil.base import factory
 from yafowil.controller import Controller
 from yafowil.utils import Tag
 from zExceptions import BadRequest
+from zExceptions import Redirect
 from zope.i18n import translate
 from zope.i18nmessageid import Message
 from zope.security import checkPermission
+
 import json
 import plone.api
 import urllib
@@ -660,10 +662,17 @@ class OrderViewBase(BrowserView):
 
     @property
     def uid(self):
-        return self.request.form['uid']
+        return self.request.form.get('uid', None)
 
     @property
     def order(self):
+        if not self.uid:
+            err = _(
+                'statusmessage_err_no_order_uid_given',
+                default='Cannot show order information because no order uid was given.'  # noqa
+            )
+            IStatusMessage(self.request).addStatusMessage(err, 'error')
+            raise Redirect(self.context.absolute_url())
         return dict(self.order_data.order.attrs)
 
     @property

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -455,6 +455,17 @@ class OrderCheckoutAdapter(CheckoutAdapter):
         return booking
 
 
+def is_billable_booking(booking):
+    """Return True, if booking is billable and should be included in order
+    summary calculations.
+    To be used in Pythons filter function::
+        filter(is_billable_booking, bookings)
+    """
+    return booking.attrs['state'] not in (
+        ifaces.STATE_RESERVED, ifaces.STATE_CANCELLED
+    )
+
+
 def _calculate_order_attr_from_bookings(bookings, attr, mixed_value):
     ret = None
     for booking in bookings:
@@ -477,7 +488,7 @@ def calculate_order_state(bookings):
 
 def calculate_order_salaried(bookings):
     return _calculate_order_attr_from_bookings(
-        bookings,
+        filter(is_billable_booking, bookings),
         'salaried',
         ifaces.SALARIED_MIXED
     )
@@ -662,7 +673,7 @@ class OrderData(OrderState):
     def net(self):
         # XXX: use decimal
         ret = 0.0
-        for booking in self.bookings:
+        for booking in filter(is_billable_booking, self.bookings):
             count = float(booking.attrs['buyable_count'])
             net = booking.attrs.get('net', 0.0)
             discount_net = float(booking.attrs['discount_net'])
@@ -673,7 +684,7 @@ class OrderData(OrderState):
     def vat(self):
         # XXX: use decimal
         ret = 0.0
-        for booking in self.bookings:
+        for booking in filter(is_billable_booking, self.bookings):
             count = float(booking.attrs['buyable_count'])
             net = booking.attrs.get('net', 0.0)
             discount_net = float(booking.attrs['discount_net'])

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -413,6 +413,7 @@ class OrderCheckoutAdapter(CheckoutAdapter):
             raise CheckoutError(msg)
         item_stock = get_item_stock(buyable)
         if item_stock.available is not None:
+            # TODO: ATTENTION: here might get removed more than available..?
             item_stock.available -= float(count)
         available = item_stock.available
         state = ifaces.STATE_NEW if available is None or available >= 0.0\
@@ -584,6 +585,7 @@ class OrderState(object):
         stock = get_item_stock(obj)
         # if stock.available is None, no stock information used
         if stock.available is not None:
+            # TODO: ATTENTION: here might get removed more than available..?
             stock.available -= float(booking.attrs['buyable_count'])
 
 

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -532,13 +532,39 @@ class OrderState(object):
             'Abstract OrderState does not implement salaried.setter')
 
     def update_item_stock(self, booking, old_state, new_state):
+        """Change stock according to transition. See table in transitions.py
+        """
         if old_state == new_state:
             return
         # XXX: fix stock item available??
-        if new_state == ifaces.STATE_NEW:
-            self.decrease_stock(booking)
-        if new_state == ifaces.STATE_CANCELLED:
-            self.increase_stock(booking)
+        if old_state == ifaces.STATE_NEW:
+            if new_state == ifaces.STATE_CANCELLED:
+                self.increase_stock(booking)
+            else:
+                # do nothing
+                pass
+        elif old_state == ifaces.STATE_RESERVED:
+            if new_state in (ifaces.STATE_PROCESSING, ifaces.STATE_FINISHED):
+                self.decrease_stock(booking)
+            else:
+                # do nothing
+                pass
+        elif old_state == ifaces.STATE_PROCESSING:
+            if new_state == ifaces.STATE_CANCELLED:
+                self.increase_stock(booking)
+            else:
+                # do nothing
+                pass
+        elif old_state == ifaces.STATE_FINISHED:
+            if new_state == ifaces.STATE_NEW:
+                # do nothing
+                pass
+        elif old_state == ifaces.STATE_CANCELLED:
+            if new_state == ifaces.STATE_NEW:
+                self.decrease_stock(booking)
+            else:
+                # do nothing
+                pass
 
     def increase_stock(self, booking):
         obj = get_object_by_uid(self.context, booking.attrs['buyable_uid'])

--- a/src/bda/plone/orders/mailnotify.py
+++ b/src/bda/plone/orders/mailnotify.py
@@ -39,6 +39,7 @@ POSSIBLE_TEMPLATE_CALLBACKS = [
     'booking_reserved_to_ordered_title',
     'global_text',
     'item_listing',
+    'reserved_item_listing'
     'order_summary',
     'payment_text',
     'stock_threshold_reached_text',
@@ -72,11 +73,22 @@ def _process_template_cb(name, tpls, args, context, order_data):
         args[name] = tpls[cb_name](context, order_data)
 
 
-def create_mail_listing(context, order_data):
+def create_mail_listing(
+    context,
+    order_data,
+    include_booking_states=(
+        ifaces.STATE_FINISHED,
+        ifaces.STATE_NEW,
+        ifaces.STATE_PROCESSING
+    )
+):
     """Create item listing for notification mail.
     """
     lines = []
     for booking in order_data.bookings:
+        state = safe_unicode(booking.attrs.get('state'))
+        if state not in include_booking_states:
+            continue
         brain = get_catalog_brain(context, booking.attrs['buyable_uid'])
         # fetch buyable
         buyable = brain.getObject()
@@ -96,7 +108,6 @@ def create_mail_listing(context, order_data):
             net=net
         )
         # XXX: discount
-        state = safe_unicode(booking.attrs.get('state'))
         state_text = u''
         if state == ifaces.STATE_RESERVED:
             state_text = u' ({0})'.format(vocabs.state_vocab()[state])
@@ -119,6 +130,14 @@ def create_mail_listing(context, order_data):
         if text:
             lines.append(_indent(text))
     return u'\n'.join(lines)
+
+
+def create_reserved_item_listing(context, order_data):
+    return create_mail_listing(
+        context,
+        order_data,
+        include_booking_states=(ifaces.STATE_RESERVED)
+    )
 
 
 def create_order_summary(context, order_data):
@@ -403,11 +422,9 @@ def notify_order_success(event, who=None):
     order_data = OrderData(event.context, uid=get_order_uid(event))
     templates = dict()
     state = order_data.state
-    if state == ifaces.STATE_RESERVED:
+    if state in (ifaces.STATE_RESERVED, state == ifaces.STATE_MIXED):
         templates.update(get_reservation_templates(event.context))
-    elif state == ifaces.STATE_MIXED:
-        # XXX: mixed templates
-        templates.update(get_reservation_templates(event.context))
+        templates['reserved_item_listing_cb'] = create_reserved_item_listing
     else:
         templates.update(get_order_templates(event.context))
     templates['item_listing_cb'] = create_mail_listing

--- a/src/bda/plone/orders/mailnotify.py
+++ b/src/bda/plone/orders/mailnotify.py
@@ -39,7 +39,7 @@ POSSIBLE_TEMPLATE_CALLBACKS = [
     'booking_reserved_to_ordered_title',
     'global_text',
     'item_listing',
-    'reserved_item_listing'
+    'reserved_item_listing',
     'order_summary',
     'payment_text',
     'stock_threshold_reached_text',
@@ -422,7 +422,7 @@ def notify_order_success(event, who=None):
     order_data = OrderData(event.context, uid=get_order_uid(event))
     templates = dict()
     state = order_data.state
-    if state in (ifaces.STATE_RESERVED, state == ifaces.STATE_MIXED):
+    if state in (ifaces.STATE_RESERVED, ifaces.STATE_MIXED):
         templates.update(get_reservation_templates(event.context))
         templates['reserved_item_listing_cb'] = create_reserved_item_listing
     else:

--- a/src/bda/plone/orders/mailtemplates.py
+++ b/src/bda/plone/orders/mailtemplates.py
@@ -72,6 +72,9 @@ Comment:
 Ordered items:
 %(item_listing)s
 
+Reserved items:
+%(reserved_item_listing)s
+
 %(order_summary)s%(global_text)s%(payment_text)s
 """
 
@@ -189,6 +192,9 @@ Kommentar:
 Bestellte Artikel:
 %(item_listing)s
 
+Reservierte Artikel:
+%(reserved_item_listing)s
+
 %(order_summary)s%(global_text)s%(payment_text)s
 """  # noqa
 
@@ -293,6 +299,9 @@ Commentaires:
 Produit commandé:
 %(item_listing)s
 
+Produit réservés:
+%(reserved_item_listing)s
+
 %(order_summary)s%(global_text)s%(payment_text)s
 """
 
@@ -379,6 +388,9 @@ Commento:
 
 Articolo ordinato:
 %(item_listing)s
+
+Articolo riservato:
+%(reserved_item_listing)s
 
 %(order_summary)s%(global_text)s%(payment_text)s
 """
@@ -468,6 +480,9 @@ Kommentar:
 
 Bestilte produkter:
 %(item_listing)s
+
+Reserverte produkter:
+%(reserved_item_listing)s
 
 %(order_summary)s%(global_text)s%(payment_text)s
 """

--- a/src/bda/plone/orders/mailtemplates.py
+++ b/src/bda/plone/orders/mailtemplates.py
@@ -103,13 +103,12 @@ Order details: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 """
 
 
-BOOKING_RESERVED_TO_ORDERED_SUBJECT_EN = u"Reservation of %s is now ordered."
+BOOKING_RESERVED_TO_ORDERED_SUBJECT_EN = u"Reservation of %s is now available."
 
 BOOKING_RESERVED_TO_ORDERED_BODY_EN = u"""
 Date: %(date)s
 
-You made a reservation of an article in our shop.
-The article became available and we could accept your ordering.
+Your reserved item is now available and our order is being processed.
 
 Ordernumber: %(ordernumber)s
 Booked item: %(booking_reserved_to_ordered_title)s
@@ -222,13 +221,12 @@ Details zur Bestellung: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 """
 
 
-BOOKING_RESERVED_TO_ORDERED_SUBJECT_DE = u"Reservierung %s ist nun bestellt."
+BOOKING_RESERVED_TO_ORDERED_SUBJECT_DE = u"Reservierung %s ist nun verfügbar."
 
 BOOKING_RESERVED_TO_ORDERED_BODY_DE = u"""
 Datum: %(date)s
 
-Sie haben eine Reservierung in unserem Shop vorgenommen.
-Der Artikel ist verfügbar geworden und wir konnten ihre Bestellung akzeptieren.
+Ihr reservierter Artikel ist verfügbar geworden und Ihre Bestellung wird nun bearbeitet.
 
 Bestellnummer: %(ordernumber)s
 Bestellter Artikel: %(booking_reserved_to_ordered_title)s

--- a/src/bda/plone/orders/transitions.py
+++ b/src/bda/plone/orders/transitions.py
@@ -4,6 +4,25 @@ from bda.plone.orders import interfaces
 from bda.plone.orders.common import BookingData
 from zope.event import notify
 
+"""
+State transitions and stock change
+
+origin state    target state    stock change
+============================================
+NEW             PROCESSING      0
+NEW             FINISHED        0
+NEW             CANCELLED       +1
+RESERVED        PROCESSING      -1
+RESERVED        FINISHED        -1
+RESERVED        CANCELLED       0
+PROCESSING      FINISH          0
+PROCESSING      CANCEL          +1
+PROCESSING      RENEW           0
+FINISHED        RENEW           0
+CANCELLED       RENEW           -1
+
+"""
+
 
 def transitions_of_main_state(state):
     """List of transitions for a given orders or bookings main state


### PR DESCRIPTION
- Make the current context as base url for ``ajaxurl`` in OrdersTable and BookingsTable.
  This way, the current subsites settings are respected, e.g. when rendering state transition dropdowns, which again sends mails and those need the correct sender.

- Reimplement ``update_item_stock`` according to transition changes, documented at the table in ``transitions.py``.

- If no ``uid`` was given when calling the ``@@order`` view, redirect to current context and show an error message instead of failing.

- In ``@@bookings`` view, group by buyable per default.

- In ``@@bookings`` view, add ``buyable_comment`` column and combine first name, last name and address information to save space.

- Don't include reserved bookings in ``OrderData`` payment information (net, vat) and don't count them when calculating the salaried state for orders.

- In mail templates, list reserved items seperately from normal ordered items.