### PR TITLE
Unicode fix for vocabulary

### DIFF
--- a/src/bda/plone/orders/vocabularies.py
+++ b/src/bda/plone/orders/vocabularies.py
@@ -71,7 +71,7 @@ def all_vendors_vocab():
     """
     vendors = get_all_vendors()
     vocab = [(IUUID(vendor),
-             u'{0} ({1})'.format(vendor.Title(), vendor.absolute_url_path()))
+             u'{0} ({1})'.format(vendor.Title().decode('utf-8', 'ignore'), vendor.absolute_url_path()))
              for vendor in vendors]
     return vocab
 
@@ -81,7 +81,7 @@ def vendors_vocab_for(user=None):
     """
     vendors = get_vendors_for(user=user)
     vocab = [(IUUID(vendor),
-             u'{0} ({1})'.format(vendor.Title(), vendor.absolute_url_path()))
+             u'{0} ({1})'.format(vendor.Title().decode('utf-8', 'ignore'), vendor.absolute_url_path()))
              for vendor in vendors]
     return vocab
 


### PR DESCRIPTION
If site name has unicode errors, the vocabulary failed ( 'Økologisk Honning')