### PR TITLE
Add invoice view, bugfixes and improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,18 @@ Changelog
 1.0a1 (unreleased)
 ------------------
 
+- Ajaxify cancel bookings.
+  [rnix]
+
+- Fix comment editing in plone 5.
+  [rnix]
+
+- Only display cancel booking action if booking not already cancelled.
+  [rnix]
+
+- Fix error in the order detail if the product no longer exists (#20).
+  [rnix]
+
 - Do not exclude reserved bookings by default from billing. This resolves
   inconsistenty introduced with
   https://github.com/bluedynamics/bda.plone.orders/pull/39 and addressed at

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 1.0a1 (unreleased)
 ------------------
 
+- Introduce ``OrderDataView`` base class for views dealing with single order
+  data.
+  [rnix]
+
 - Add HTML support for order related notification mails.
   [rnix]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Changelog
   and ``DirectInvoiceView``.
   [rnix]
 
+- Add invoice view.
+  [rnix]
+
 - Remove duplicate ``Translate`` class from
   ``bda.plone.orders.browser.contacts``.
   [rnix]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 1.0a1 (unreleased)
 ------------------
 
+- Do not exclude reserved bookings by default from billing. This resolves
+  inconsistenty introduced with
+  https://github.com/bluedynamics/bda.plone.orders/pull/39 and addressed at
+  https://github.com/bluedynamics/bda.plone.orders/issues/45.
+  [rnix]
+
 - Introduce ``ProtectedOrderDataView`` and use as base for ``DirectOrderView``
   and ``DirectInvoiceView``.
   [rnix]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,19 @@ Changelog
 1.0a1 (unreleased)
 ------------------
 
+- Introduce ``ProtectedOrderDataView`` and use as base for ``DirectOrderView``
+  and ``DirectInvoiceView``.
+  [rnix]
+
+- Remove duplicate ``Translate`` class from
+  ``bda.plone.orders.browser.contacts``.
+  [rnix]
+
+- Rename ``OrdersContentView`` to ``ContentViewBase``. Provide B/C alias.
+  Introduce view configuration properties ``do_disable_border``,
+  ``do_disable_left_column`` and ``do_disable_right_column``.
+  [rnix]
+
 - Introduce ``OrderDataView`` base class for views dealing with single order
   data.
   [rnix]

--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,11 @@ Create translations
 TODO
 ====
 
+- Overhaul order view. Display discounted item price, etc.
+
+- Think about adding notification text to booking data in checkout adapter if
+  we want to display related text in invoice.
+
 - Add vendor support to invoices.
 
 - Add a flag ``charge_if_backorder`` to ``IStockBehavior``, so we have control

--- a/README.rst
+++ b/README.rst
@@ -279,13 +279,13 @@ Create translations
 TODO
 ====
 
-- i18n
+- Rename salaried to paid all over the place.
 
-- icons in orders view actions
+- Split up bda.plone.orders.browser.views.
 
-- icons in contacts view actions
+- Icons in orders view actions
 
-- booking billable
+- Icons in contacts view actions
 
 - Overhaul order view. Display discounted item price, etc.
 
@@ -294,9 +294,11 @@ TODO
 
 - Add vendor support to invoices.
 
-- Add a flag ``charge_if_backorder`` to ``IStockBehavior``, so we have control
-  per buyable item, and a control panel setting with the default of this value
-  for all buyables (Issue #45).
+- Properly implement initially non-billable bookings. Add a flag
+  ``charge_if_backorder`` to ``IStockBehavior``, so we have control per buyable
+  item, and a control panel setting with the default of this value
+  for all buyables. Implement UI to carry back unbilled backorders. Adopt order
+  and invoive views (Issue #45).
 
 - Adopt text notification mail generation to mako templates and move existing
   text mail generation to legacy module, with flag to switch between old and

--- a/README.rst
+++ b/README.rst
@@ -279,9 +279,17 @@ Create translations
 TODO
 ====
 
+- Add vendor support to invoices.
+
+- Add a flag ``charge_if_backorder`` to ``IStockBehavior``, so we have control
+  per buyable item, and a control panel setting with the default of this value
+  for all buyables (Issue #45).
+
 - Adopt text notification mail generation to mako templates and move existing
   text mail generation to legacy module, with flag to switch between old and
-  new style text generation.
+  new style text generation. As fallback add transformation of HTML mail to
+  plain text version.
+  (https://github.com/collective/Products.EasyNewsletter/blob/master/Products/EasyNewsletter/utils/mail.py#L112)
 
 - @@orders in lineage subsites should only list orders in that path.
 

--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,12 @@ Create translations
 TODO
 ====
 
+- i18n
+
+- icons in orders view
+
+- booking billable
+
 - Overhaul order view. Display discounted item price, etc.
 
 - Think about adding notification text to booking data in checkout adapter if

--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,8 @@ Create translations
 TODO
 ====
 
+- Export orders bug.
+
 - Rename salaried to paid all over the place.
 
 - Split up bda.plone.orders.browser.views.

--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,9 @@ TODO
 
 - i18n
 
-- icons in orders view
+- icons in orders view actions
+
+- icons in contacts view actions
 
 - booking billable
 

--- a/README.rst
+++ b/README.rst
@@ -279,7 +279,9 @@ Create translations
 TODO
 ====
 
-- Export orders bug.
+- Store cart and item discount rules in checkout adapter instead of actual
+  discount values in order to reliably modify orders while keeping invoice and
+  order summary views sane.
 
 - Rename salaried to paid all over the place.
 

--- a/src/bda/plone/orders/browser/bookings.py
+++ b/src/bda/plone/orders/browser/bookings.py
@@ -10,7 +10,7 @@ from bda.plone.orders import message_factory as _
 from bda.plone.orders import permissions
 from bda.plone.orders import vocabularies as vocabs
 from bda.plone.orders.browser.dropdown import BaseDropdown
-from bda.plone.orders.browser.views import OrdersContentView
+from bda.plone.orders.browser.views import ContentViewBase
 from bda.plone.orders.browser.views import Transition
 from bda.plone.orders.browser.views import customers_form_vocab
 from bda.plone.orders.browser.views import salaried_form_vocab
@@ -119,7 +119,7 @@ class BookingSalariedTransition(BookingTransition):
     dropdown = BookingSalariedDropdown
 
 
-class BookingsView(OrdersContentView):
+class BookingsView(ContentViewBase):
     table_view_name = '@@bookingstable'
 
     def bookings_table(self):
@@ -527,7 +527,6 @@ class BookingsTable(BrowserView):
         )
         return json.dumps(data)
 
-# helper methods
     def _get_price(self, record):
         """
         returns net + vat price

--- a/src/bda/plone/orders/browser/configure.zcml
+++ b/src/bda/plone/orders/browser/configure.zcml
@@ -3,8 +3,6 @@
            xmlns:browser="http://namespaces.zope.org/browser"
            xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <!-- ORDERS -->
-
   <!-- orders view -->
   <browser:page
     for="*"
@@ -39,9 +37,6 @@
     permission="bda.plone.orders.ViewOwnOrders"
     layer="..interfaces.IOrdersExtensionLayer" />
 
-
-  <!-- BOOKINGS -->
-
   <!-- bookings view -->
   <browser:page
     for="*"
@@ -68,9 +63,6 @@
     class=".bookings.BookingsTable"
     permission="bda.plone.orders.ViewOrders"
     layer="..interfaces.IOrdersExtensionLayer" />
-
-
-  <!-- OTHER -->
 
   <!-- contacts view -->
   <browser:page
@@ -240,6 +232,30 @@
     template="order_done.pt"
     class=".views.OrderDone"
     permission="zope2.View"
+    layer="..interfaces.IOrdersExtensionLayer" />
+
+  <!-- invoice view -->
+  <browser:page
+    for="*"
+    name="invoice"
+    template="invoice.pt"
+    class=".views.InvoiceView"
+    permission="bda.plone.orders.ViewOrders"
+    layer="..interfaces.IOrdersExtensionLayer" />
+
+  <browser:page
+    for="zope.component.interfaces.ISite"
+    name="myinvoice"
+    template="invoice.pt"
+    class=".views.MyInvoiceView"
+    permission="bda.plone.orders.ViewOwnOrders"
+    layer="..interfaces.IOrdersExtensionLayer" />
+
+  <browser:page
+    for="zope.component.interfaces.ISite"
+    name="showinvoice"
+    class=".views.DirectInvoiceView"
+    permission="bda.plone.orders.ViewOrderDirectly"
     layer="..interfaces.IOrdersExtensionLayer" />
 
   <!-- global mail templates -->

--- a/src/bda/plone/orders/browser/configure.zcml
+++ b/src/bda/plone/orders/browser/configure.zcml
@@ -245,14 +245,6 @@
 
   <browser:page
     for="zope.component.interfaces.ISite"
-    name="myinvoice"
-    template="invoice.pt"
-    class=".views.MyInvoiceView"
-    permission="bda.plone.orders.ViewOwnOrders"
-    layer="..interfaces.IOrdersExtensionLayer" />
-
-  <browser:page
-    for="zope.component.interfaces.ISite"
     name="showinvoice"
     class=".views.DirectInvoiceView"
     permission="bda.plone.orders.ViewOrderDirectly"

--- a/src/bda/plone/orders/browser/configure.zcml
+++ b/src/bda/plone/orders/browser/configure.zcml
@@ -238,7 +238,7 @@
   <browser:page
     for="*"
     name="invoice"
-    template="invoice.pt"
+    template="invoice_view.pt"
     class=".views.InvoiceView"
     permission="bda.plone.orders.ViewOrders"
     layer="..interfaces.IOrdersExtensionLayer" />

--- a/src/bda/plone/orders/browser/contacts.py
+++ b/src/bda/plone/orders/browser/contacts.py
@@ -1,31 +1,20 @@
 # -*- coding: utf-8 -*-
-from bda.plone.orders import message_factory as _
-from bda.plone.orders.browser.views import OrdersContentView
-from bda.plone.orders.contacts import get_contacts_soup
 from Products.CMFPlone.utils import safe_unicode
+from bda.plone.orders import message_factory as _
+from bda.plone.orders.browser.views import ContentViewBase
+from bda.plone.orders.contacts import get_contacts_soup
+from bda.plone.orders.views import Translate
 from repoze.catalog.query import Contains
 from repoze.catalog.query import Gt
 from yafowil.utils import Tag
 from zope.i18n import translate
 from zope.i18nmessageid import Message
-
 import json
 import plone.api
 import yafowil.loader  # noqa
 
 
-class Translate(object):
-
-    def __init__(self, request):
-        self.request = request
-
-    def __call__(self, msg):
-        if not isinstance(msg, Message):
-            return msg
-        return translate(msg, context=self.request)
-
-
-class ContactsTable(OrdersContentView):
+class ContactsTable(ContentViewBase):
     table_id = 'bdaplonecontacts'
     data_view_name = '@@contactsdata'
 

--- a/src/bda/plone/orders/browser/contacts.py
+++ b/src/bda/plone/orders/browser/contacts.py
@@ -2,8 +2,8 @@
 from Products.CMFPlone.utils import safe_unicode
 from bda.plone.orders import message_factory as _
 from bda.plone.orders.browser.views import ContentViewBase
+from bda.plone.orders.browser.views import Translate
 from bda.plone.orders.contacts import get_contacts_soup
-from bda.plone.orders.views import Translate
 from repoze.catalog.query import Contains
 from repoze.catalog.query import Gt
 from yafowil.utils import Tag

--- a/src/bda/plone/orders/browser/dropdown.py
+++ b/src/bda/plone/orders/browser/dropdown.py
@@ -4,6 +4,8 @@ import urllib
 
 
 class BaseDropdown(object):
+    """Base class for order related dropdown menus.
+    """
     render = ViewPageTemplateFile('dropdown.pt')
     name = ''
     css = 'dropdown'

--- a/src/bda/plone/orders/browser/export.py
+++ b/src/bda/plone/orders/browser/export.py
@@ -12,7 +12,7 @@ from bda.plone.orders import message_factory as _
 from bda.plone.orders import permissions
 from bda.plone.orders import safe_encode
 from bda.plone.orders import safe_filename
-from bda.plone.orders.browser.views import OrdersContentView
+from bda.plone.orders.browser.views import ContentViewBase
 from bda.plone.orders.browser.views import customers_form_vocab
 from bda.plone.orders.browser.views import vendors_form_vocab
 from bda.plone.orders.common import DT_FORMAT
@@ -136,7 +136,7 @@ def cleanup_for_csv(value):
     return safe_encode(value)
 
 
-class ExportOrdersForm(YAMLForm, OrdersContentView):
+class ExportOrdersForm(YAMLForm, ContentViewBase):
     browser_template = ViewPageTemplateFile('export.pt')
     form_template = 'bda.plone.orders.browser:forms/orders_export.yaml'
     message_factory = _

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -1,0 +1,80 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="bda.plone.orders">
+
+<body>
+
+<metal:main fill-slot="main">
+  <tal:main-macro metal:define-macro="main">
+
+    <div class="invoice"
+         tal:define="vendor view/vendor;
+                     order view/order">
+
+      <div class="invoice_vendor">
+        <strong tal:content="vendor/title">title</strong>
+        <br />
+        <span tal:replace="vendor/subtitle">subtitle</span>
+        <br />
+        <br />
+        <span tal:replace="vendor/firstname">first name</span>
+        <span tal:replace="vendor/lastname">last name</span>
+        <br />
+        <span tal:replace="vendor/street">street</span>
+        <br />
+        <span tal:replace="vendor/zip">zip</span>
+        <span tal:replace="vendor/city">city</span>
+        <br />
+        <span tal:replace="python:view.country(vendor['country'])">
+          country
+        </span>
+        <br />
+        <span i18n:translate="invoice_tel">Phone:</span>
+        <span tal:replace="vendor/phone">phone</span>
+        <br />
+        <span i18n:translate="invoice_email">Email:</span>
+        <span tal:replace="vendor/email">email</span>
+        <br />
+        <span i18n:translate="invoice_web">Web:</span>
+        <span tal:replace="vendor/web">web</span>
+        <br />
+      </div>
+
+      <div class="invoice_receiver">
+        <span tal:replace="view/gender">gender</span>
+        <span tal:replace="order/personal_data.firstname">first name</span>
+        <span tal:replace="order/personal_data.lastname">last name</span>
+        <br />
+        <span tal:replace="order/personal_data.company">company</span>
+        <br />
+        <span tal:replace="order/billing_address.street">street</span>
+        <br />
+        <span tal:replace="order/billing_address.zip">zip</span>
+        <span tal:replace="order/billing_address.city">city</span>
+        <br />
+        <span tal:replace="python:view.country(order['billing_address.country'])">
+          country
+        </span>
+      </div>
+
+      <h1 class="invoice_title">
+        <span i18n:translate="invoice">Invoice</span>
+        <span tal:replace="view/invoice_number">INV12345<span>
+      </h1>
+
+      <span class="invoice_date">
+        <span tal:replace="vendor/city">city</span>,
+        <span tal:replace="python:view.format_date(order['created'])">date</span>
+      </span>
+
+    </div>
+
+  </tal:main-macro>
+</metal:main>
+
+</body>
+</html>

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -13,7 +13,8 @@
 
     <div class="invoice"
          tal:define="sender view/sender;
-                     order view/order">
+                     order view/order;
+                     summary view/summary">
 
       <h1 class="invoice_title"
           i18n:translate="your_invoice">Your Invoice</h1>
@@ -124,6 +125,128 @@
             </div>
           </div>
         </tal:item>
+      </div>
+
+      <div class="invoice_summary">
+
+        <div class="invoice_summary_section"
+             tal:condition="summary/cart_net">
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <span i18n:translate="invoice_cart_net">Net</span>
+            </div>
+            <div class="invoice_summary_value">
+              <span tal:replace="python:view.ascur(summary['cart_net'])" />
+              <span tal:replace="summary/currency" />
+            </div>
+          </div>
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <span i18n:translate="invoice_cart_vat">VAT</span>
+            </div>
+            <div class="invoice_summary_value">
+              <span tal:replace="python:view.ascur(summary['cart_vat'])" />
+              <span tal:replace="summary/currency" />
+            </div>
+          </div>
+
+        </div>
+
+        <div class="invoice_summary_section"
+             tal:condition="summary/discount_net">
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <span i18n:translate="invoice_discount_net">Discount Net</span>
+            </div>
+            <div class="invoice_summary_value">
+              <span class="red">
+                -<span tal:replace="python:view.ascur(summary['discount_net'])" />
+                <span tal:replace="summary/currency" />
+              </span>
+            </div>
+          </div>
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <span i18n:translate="invoice_discount_vat">Discount VAT</span>
+            </div>
+            <div class="invoice_summary_value">
+              <span class="red">
+                -<span tal:replace="python:view.ascur(summary['discount_vat'])" />
+                <span tal:replace="summary/currency" />
+              </span>
+            </div>
+          </div>
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <strong i18n:translate="invoice_discount_total">Discount Total</strong>
+            </div>
+            <div class="invoice_summary_value">
+              <strong class="red">
+                -<span tal:replace="python:view.ascur(summary['discount_total'])" />
+                <span tal:replace="summary/currency" />
+              </strong>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="invoice_summary_section"
+             tal:condition="summary/shipping_net">
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <span i18n:translate="invoice_shipping_net">Shipping Net</span>
+            </div>
+            <div class="invoice_summary_value">
+              <span tal:replace="python:view.ascur(summary['shipping_net'])" />
+              <span tal:replace="summary/currency" />
+            </div>
+          </div>
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <span i18n:translate="invoice_shipping_vat">Shipping VAT</span>
+            </div>
+            <div class="invoice_summary_value">
+              <span tal:replace="python:view.ascur(summary['shipping_vat'])" />
+              <span tal:replace="summary/currency" />
+            </div>
+          </div>
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <strong i18n:translate="invoice_shipping_total">Shipping Total</strong>
+            </div>
+            <div class="invoice_summary_value">
+              <strong>
+                <span tal:replace="python:view.ascur(summary['shipping_total'])" />
+                <span tal:replace="summary/currency" />
+              </strong>
+            </div>
+          </div>
+
+        </div>
+
+        <div class="invoice_summary_section">
+
+          <div class="invoice_summary_row">
+            <div class="invoice_summary_label">
+              <strong i18n:translate="invoice_cart_total">Total</strong>
+            </div>
+            <div class="invoice_summary_value">
+              <strong>
+                <span tal:replace="python:view.ascur(summary['cart_total'])" />
+                <span tal:replace="summary/currency" />
+              </strong>
+            </div>
+          </div>
+
+        </div>
       </div>
 
     </div>

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -20,12 +20,12 @@
           i18n:translate="your_invoice">Your Invoice</h1>
 
       <div class="invoice_sender">
-        <strong tal:content="sender/title">title</strong>
+        <strong tal:content="sender/company">company</strong>
         <br />
-        <tal:subtitle condition="sender/subtitle">
-          <span tal:replace="sender/subtitle">subtitle</span>
+        <tal:companyadd condition="sender/companyadd">
+          <span tal:replace="sender/companyadd">company additional</span>
           <br />
-        </tal:subtitle>
+        </tal:companyadd>
         <br />
         <span tal:replace="sender/firstname">first name</span>
         <span tal:replace="sender/lastname">last name</span>
@@ -272,10 +272,10 @@
         <span tal:replace="sender/lastname">last name</span>
         <br />
         <br />
-        <strong tal:content="sender/title">title</strong>
-        <tal:subtitle condition="sender/subtitle">
-          - <strong tal:content="sender/subtitle">subtitle</strong>
-        </tal:subtitle>
+        <strong tal:content="sender/company">company</strong>
+        <tal:companyadd condition="sender/companyadd">
+          - <strong tal:content="sender/companyadd">company additional</strong>
+        </tal:companyadd>
       </div>
 
     </div>

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -1,287 +1,272 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
-      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      lang="en"
-      metal:use-macro="here/main_template/macros/master"
-      i18n:domain="bda.plone.orders">
+<div class="invoice"
+     xmlns="http://www.w3.org/1999/xhtml"
+     xmlns:tal="http://xml.zope.org/namespaces/tal"
+     xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+     i18n:domain="bda.plone.orders"
+     tal:define="sender view/sender;
+                 order view/order;
+                 summary view/summary">
 
-<body>
+  <h1 class="invoice_title"
+      i18n:translate="your_invoice">Your Invoice</h1>
 
-<metal:main fill-slot="main">
-  <tal:main-macro metal:define-macro="main">
+  <div class="invoice_sender">
+    <strong tal:content="sender/company">company</strong>
+    <br />
+    <tal:companyadd condition="sender/companyadd">
+      <span tal:replace="sender/companyadd">company additional</span>
+      <br />
+    </tal:companyadd>
+    <br />
+    <span tal:replace="sender/firstname">first name</span>
+    <span tal:replace="sender/lastname">last name</span>
+    <br />
+    <span tal:replace="sender/street">street</span>
+    <br />
+    <span tal:replace="sender/zip">zip</span>
+    <span tal:replace="sender/city">city</span>
+    <br />
+    <span tal:replace="python:view.country(sender['country'])">
+      country
+    </span>
+    <br />
+    <tal:phone condition="sender/phone">
+      <span tal:replace="sender/phone">phone</span>
+      <br />
+    </tal:phone>
+    <tal:email condition="sender/email">
+      <span tal:replace="sender/email">email</span>
+      <br />
+    </tal:email>
+    <tal:web condition="sender/web">
+      <span tal:replace="sender/web">web</span>
+      <br />
+    </tal:web>
+  </div>
 
-    <div class="invoice"
-         tal:define="sender view/sender;
-                     order view/order;
-                     summary view/summary">
+  <div class="invoice_receiver">
+    <span tal:replace="order/personal_data.firstname">first name</span>
+    <span tal:replace="order/personal_data.lastname">last name</span>
+    <br />
+    <tal:company condition="order/personal_data.company">
+      <span tal:replace="order/personal_data.company">company</span>
+      <br />
+    </tal:company>
+    <span tal:replace="order/billing_address.street">street</span>
+    <br />
+    <span tal:replace="order/billing_address.zip">zip</span>
+    <span tal:replace="order/billing_address.city">city</span>
+    <br />
+    <span tal:replace="python:view.country(order['billing_address.country'])">
+      country
+    </span>
+  </div>
 
-      <h1 class="invoice_title"
-          i18n:translate="your_invoice">Your Invoice</h1>
+  <h2 class="invoice_number">
+    <span i18n:translate="invoice">Invoice</span>
+    <span tal:replace="view/invoice_number">INV12345</span>
+  </h2>
 
-      <div class="invoice_sender">
-        <strong tal:content="sender/company">company</strong>
-        <br />
-        <tal:companyadd condition="sender/companyadd">
-          <span tal:replace="sender/companyadd">company additional</span>
-          <br />
-        </tal:companyadd>
-        <br />
-        <span tal:replace="sender/firstname">first name</span>
-        <span tal:replace="sender/lastname">last name</span>
-        <br />
-        <span tal:replace="sender/street">street</span>
-        <br />
-        <span tal:replace="sender/zip">zip</span>
-        <span tal:replace="sender/city">city</span>
-        <br />
-        <span tal:replace="python:view.country(sender['country'])">
-          country
-        </span>
-        <br />
-        <tal:phone condition="sender/phone">
-          <span tal:replace="sender/phone">phone</span>
-          <br />
-        </tal:phone>
-        <tal:email condition="sender/email">
-          <span tal:replace="sender/email">email</span>
-          <br />
-        </tal:email>
-        <tal:web condition="sender/web">
-          <span tal:replace="sender/web">web</span>
-          <br />
-        </tal:web>
+  <h3 class="invoice_date">
+    <span tal:replace="sender/city">city</span>,
+    <span tal:replace="view/created">date</span>
+  </h3>
+
+  <div class="invoice_listing">
+    <div class="invoice_listing_head">
+      <div class="invoice_listing_amount">
+        <strong i18n:translate="invoice_listing_amount">Amount</strong>
       </div>
-
-      <div class="invoice_receiver">
-        <span tal:replace="order/personal_data.firstname">first name</span>
-        <span tal:replace="order/personal_data.lastname">last name</span>
-        <br />
-        <tal:company condition="order/personal_data.company">
-          <span tal:replace="order/personal_data.company">company</span>
-          <br />
-        </tal:company>
-        <span tal:replace="order/billing_address.street">street</span>
-        <br />
-        <span tal:replace="order/billing_address.zip">zip</span>
-        <span tal:replace="order/billing_address.city">city</span>
-        <br />
-        <span tal:replace="python:view.country(order['billing_address.country'])">
-          country
-        </span>
+      <div class="invoice_listing_position">
+        <strong i18n:translate="invoice_listing_position">Position</strong>
       </div>
-
-      <h2 class="invoice_number">
-        <span i18n:translate="invoice">Invoice</span>
-        <span tal:replace="view/invoice_number">INV12345</span>
-      </h2>
-
-      <h3 class="invoice_date">
-        <span tal:replace="sender/city">city</span>,
-        <span tal:replace="view/created">date</span>
-      </h3>
-
-      <div class="invoice_listing">
-        <div class="invoice_listing_head">
-          <div class="invoice_listing_amount">
-            <strong i18n:translate="invoice_listing_amount">Amount</strong>
-          </div>
-          <div class="invoice_listing_position">
-            <strong i18n:translate="invoice_listing_position">Position</strong>
-          </div>
-          <div class="invoice_listing_price">
-            <strong i18n:translate="invoice_listing_price">Price</strong>
-          </div>
-        </div>
-
-        <tal:item repeat="item view/listing">
-          <div class="invoice_listing_item">
-            <div class="invoice_listing_amount">
-              <span tal:replace="item/count">count</span>
-              <span tal:replace="item/quantity_unit">quantity</span>
-            </div>
-
-            <div class="invoice_listing_position">
-              <span tal:replace="item/title">title</span>
-              <tal:comment condition="item/comment">
-                (<span tal:replace="item/comment">comment</span>)
-              </tal:comment>
-            </div>
-
-            <div class="invoice_listing_price">
-              <tal:without_discount condition="not:item/discount_net">
-                <tal:price replace="python:view.ascur(item['net'])" />
-                <tal:currency replace="item/currency" />
-              </tal:without_discount>
-
-              <tal:with_discount condition="item/discount_net">
-                <span class="original_price">
-                  <tal:price replace="python:view.ascur(item['net'])" />
-                  <tal:currency replace="item/currency" />
-                </span>
-                <tal:price replace="python:view.ascur(item['net'] - item['discount_net'])" />
-                <tal:currency replace="item/currency" />
-              </tal:with_discount>
-            </div>
-          </div>
-        </tal:item>
+      <div class="invoice_listing_price">
+        <strong i18n:translate="invoice_listing_price">Price</strong>
       </div>
+    </div>
 
-      <div class="invoice_summary">
-
-        <div class="invoice_summary_section"
-             tal:condition="summary/cart_net">
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <span i18n:translate="invoice_cart_net">Net</span>
-            </div>
-            <div class="invoice_summary_value">
-              <span tal:replace="python:view.ascur(summary['cart_net'])" />
-              <span tal:replace="summary/currency" />
-            </div>
-          </div>
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <span i18n:translate="invoice_cart_vat">VAT</span>
-            </div>
-            <div class="invoice_summary_value">
-              <span tal:replace="python:view.ascur(summary['cart_vat'])" />
-              <span tal:replace="summary/currency" />
-            </div>
-          </div>
-
+    <tal:item repeat="item view/listing">
+      <div class="invoice_listing_item">
+        <div class="invoice_listing_amount">
+          <span tal:replace="item/count">count</span>
+          <span tal:replace="item/quantity_unit">quantity</span>
         </div>
 
-        <div class="invoice_summary_section"
-             tal:condition="summary/discount_net">
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <span i18n:translate="invoice_discount_net">Discount Net</span>
-            </div>
-            <div class="invoice_summary_value">
-              <span class="red">
-                -<span tal:replace="python:view.ascur(summary['discount_net'])" />
-                <span tal:replace="summary/currency" />
-              </span>
-            </div>
-          </div>
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <span i18n:translate="invoice_discount_vat">Discount VAT</span>
-            </div>
-            <div class="invoice_summary_value">
-              <span class="red">
-                -<span tal:replace="python:view.ascur(summary['discount_vat'])" />
-                <span tal:replace="summary/currency" />
-              </span>
-            </div>
-          </div>
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <strong i18n:translate="invoice_discount_total">Discount Total</strong>
-            </div>
-            <div class="invoice_summary_value">
-              <strong class="red">
-                -<span tal:replace="python:view.ascur(summary['discount_total'])" />
-                <span tal:replace="summary/currency" />
-              </strong>
-            </div>
-          </div>
-
+        <div class="invoice_listing_position">
+          <span tal:replace="item/title">title</span>
+          <tal:comment condition="item/comment">
+            (<span tal:replace="item/comment">comment</span>)
+          </tal:comment>
         </div>
 
-        <div class="invoice_summary_section"
-             tal:condition="summary/shipping_net">
+        <div class="invoice_listing_price">
+          <tal:without_discount condition="not:item/discount_net">
+            <tal:price replace="python:view.ascur(item['net'])" />
+            <tal:currency replace="item/currency" />
+          </tal:without_discount>
 
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <span i18n:translate="invoice_shipping_net">Shipping Net</span>
-            </div>
-            <div class="invoice_summary_value">
-              <span tal:replace="python:view.ascur(summary['shipping_net'])" />
-              <span tal:replace="summary/currency" />
-            </div>
-          </div>
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <span i18n:translate="invoice_shipping_vat">Shipping VAT</span>
-            </div>
-            <div class="invoice_summary_value">
-              <span tal:replace="python:view.ascur(summary['shipping_vat'])" />
-              <span tal:replace="summary/currency" />
-            </div>
-          </div>
-
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <strong i18n:translate="invoice_shipping_total">Shipping Total</strong>
-            </div>
-            <div class="invoice_summary_value">
-              <strong>
-                <span tal:replace="python:view.ascur(summary['shipping_total'])" />
-                <span tal:replace="summary/currency" />
-              </strong>
-            </div>
-          </div>
-
+          <tal:with_discount condition="item/discount_net">
+            <span class="original_price">
+              <tal:price replace="python:view.ascur(item['net'])" />
+              <tal:currency replace="item/currency" />
+            </span>
+            <tal:price replace="python:view.ascur(item['net'] - item['discount_net'])" />
+            <tal:currency replace="item/currency" />
+          </tal:with_discount>
         </div>
+      </div>
+    </tal:item>
+  </div>
 
-        <div class="invoice_summary_section">
+  <div class="invoice_summary">
 
-          <div class="invoice_summary_row">
-            <div class="invoice_summary_label">
-              <strong i18n:translate="invoice_cart_total">Total</strong>
-            </div>
-            <div class="invoice_summary_value">
-              <strong>
-                <span tal:replace="python:view.ascur(summary['cart_total'])" />
-                <span tal:replace="summary/currency" />
-              </strong>
-            </div>
-          </div>
+    <div class="invoice_summary_section"
+         tal:condition="summary/cart_net">
 
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <span i18n:translate="invoice_cart_net">Net</span>
+        </div>
+        <div class="invoice_summary_value">
+          <span tal:replace="python:view.ascur(summary['cart_net'])" />
+          <span tal:replace="summary/currency" />
         </div>
       </div>
 
-      <div class="invoice_bank_connection">
-        <strong>IBAN</strong>
-        <span tal:replace="sender/iban">
-        <br />
-
-        <strong>BIC</strong>
-        <span tal:replace="sender/bic">
-        <br />
-      </div>
-
-      <div class="invoice_footer">
-        <span i18n:translate="invoice_prices_in_currency">All prices in</span>
-        <span tal:replace="summary/currency">
-        <br />
-        <br />
-        <br />
-        <span i18n:translate="invoice_kind_regards">Kind regards</span>,
-        <br />
-        <br />
-        <span tal:replace="sender/firstname">first name</span>
-        <span tal:replace="sender/lastname">last name</span>
-        <br />
-        <br />
-        <strong tal:content="sender/company">company</strong>
-        <tal:companyadd condition="sender/companyadd">
-          - <strong tal:content="sender/companyadd">company additional</strong>
-        </tal:companyadd>
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <span i18n:translate="invoice_cart_vat">VAT</span>
+        </div>
+        <div class="invoice_summary_value">
+          <span tal:replace="python:view.ascur(summary['cart_vat'])" />
+          <span tal:replace="summary/currency" />
+        </div>
       </div>
 
     </div>
 
-  </tal:main-macro>
-</metal:main>
+    <div class="invoice_summary_section"
+         tal:condition="summary/discount_net">
 
-</body>
-</html>
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <span i18n:translate="invoice_discount_net">Discount Net</span>
+        </div>
+        <div class="invoice_summary_value">
+          <span class="red">
+            -<span tal:replace="python:view.ascur(summary['discount_net'])" />
+            <span tal:replace="summary/currency" />
+          </span>
+        </div>
+      </div>
+
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <span i18n:translate="invoice_discount_vat">Discount VAT</span>
+        </div>
+        <div class="invoice_summary_value">
+          <span class="red">
+            -<span tal:replace="python:view.ascur(summary['discount_vat'])" />
+            <span tal:replace="summary/currency" />
+          </span>
+        </div>
+      </div>
+
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <strong i18n:translate="invoice_discount_total">Discount Total</strong>
+        </div>
+        <div class="invoice_summary_value">
+          <strong class="red">
+            -<span tal:replace="python:view.ascur(summary['discount_total'])" />
+            <span tal:replace="summary/currency" />
+          </strong>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="invoice_summary_section"
+         tal:condition="summary/shipping_net">
+
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <span i18n:translate="invoice_shipping_net">Shipping Net</span>
+        </div>
+        <div class="invoice_summary_value">
+          <span tal:replace="python:view.ascur(summary['shipping_net'])" />
+          <span tal:replace="summary/currency" />
+        </div>
+      </div>
+
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <span i18n:translate="invoice_shipping_vat">Shipping VAT</span>
+        </div>
+        <div class="invoice_summary_value">
+          <span tal:replace="python:view.ascur(summary['shipping_vat'])" />
+          <span tal:replace="summary/currency" />
+        </div>
+      </div>
+
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <strong i18n:translate="invoice_shipping_total">Shipping Total</strong>
+        </div>
+        <div class="invoice_summary_value">
+          <strong>
+            <span tal:replace="python:view.ascur(summary['shipping_total'])" />
+            <span tal:replace="summary/currency" />
+          </strong>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="invoice_summary_section">
+
+      <div class="invoice_summary_row">
+        <div class="invoice_summary_label">
+          <strong i18n:translate="invoice_cart_total">Total</strong>
+        </div>
+        <div class="invoice_summary_value">
+          <strong>
+            <span tal:replace="python:view.ascur(summary['cart_total'])" />
+            <span tal:replace="summary/currency" />
+          </strong>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="invoice_bank_connection">
+    <strong>IBAN</strong>
+    <span tal:replace="sender/iban">
+    <br />
+
+    <strong>BIC</strong>
+    <span tal:replace="sender/bic">
+    <br />
+  </div>
+
+  <div class="invoice_footer">
+    <span i18n:translate="invoice_prices_in_currency">All prices in</span>
+    <span tal:replace="summary/currency">
+    <br />
+    <br />
+    <br />
+    <span i18n:translate="invoice_kind_regards">Kind regards</span>,
+    <br />
+    <br />
+    <span tal:replace="sender/firstname">first name</span>
+    <span tal:replace="sender/lastname">last name</span>
+    <br />
+    <br />
+    <strong tal:content="sender/company">company</strong>
+    <tal:companyadd condition="sender/companyadd">
+      - <strong tal:content="sender/companyadd">company additional</strong>
+    </tal:companyadd>
+  </div>
+
+</div>

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -249,6 +249,35 @@
         </div>
       </div>
 
+      <div class="invoice_bank_connection">
+        <strong>IBAN</strong>
+        <span tal:replace="sender/iban">
+        <br />
+
+        <strong>BIC</strong>
+        <span tal:replace="sender/bic">
+        <br />
+      </div>
+
+      <div class="invoice_footer">
+        <span i18n:translate="invoice_prices_in_currency">All prices in</span>
+        <span tal:replace="summary/currency">
+        <br />
+        <br />
+        <br />
+        <span i18n:translate="invoice_kind_regards">Kind regards</span>,
+        <br />
+        <br />
+        <span tal:replace="sender/firstname">first name</span>
+        <span tal:replace="sender/lastname">last name</span>
+        <br />
+        <br />
+        <strong tal:content="sender/title">title</strong>
+        <tal:subtitle condition="sender/subtitle">
+          - <strong tal:content="sender/subtitle">subtitle</strong>
+        </tal:subtitle>
+      </div>
+
     </div>
 
   </tal:main-macro>

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -12,40 +12,47 @@
   <tal:main-macro metal:define-macro="main">
 
     <div class="invoice"
-         tal:define="vendor view/vendor;
+         tal:define="sender view/sender;
                      order view/order">
 
-      <div class="invoice_vendor">
-        <strong tal:content="vendor/title">title</strong>
+      <h1 class="invoice_title"
+          i18n:translate="your_invoice">Your Invoice</h1>
+
+      <div class="invoice_sender">
+        <strong tal:content="sender/title">title</strong>
         <br />
-        <span tal:replace="vendor/subtitle">subtitle</span>
+        <tal:subtitle condition="sender/subtitle">
+          <span tal:replace="sender/subtitle">subtitle</span>
+          <br />
+        </tal:subtitle>
         <br />
+        <span tal:replace="sender/firstname">first name</span>
+        <span tal:replace="sender/lastname">last name</span>
         <br />
-        <span tal:replace="vendor/firstname">first name</span>
-        <span tal:replace="vendor/lastname">last name</span>
+        <span tal:replace="sender/street">street</span>
         <br />
-        <span tal:replace="vendor/street">street</span>
+        <span tal:replace="sender/zip">zip</span>
+        <span tal:replace="sender/city">city</span>
         <br />
-        <span tal:replace="vendor/zip">zip</span>
-        <span tal:replace="vendor/city">city</span>
-        <br />
-        <span tal:replace="python:view.country(vendor['country'])">
+        <span tal:replace="python:view.country(sender['country'])">
           country
         </span>
         <br />
-        <span i18n:translate="invoice_tel">Phone:</span>
-        <span tal:replace="vendor/phone">phone</span>
-        <br />
-        <span i18n:translate="invoice_email">Email:</span>
-        <span tal:replace="vendor/email">email</span>
-        <br />
-        <span i18n:translate="invoice_web">Web:</span>
-        <span tal:replace="vendor/web">web</span>
-        <br />
+        <tal:phone condition="sender/phone">
+          <span tal:replace="sender/phone">phone</span>
+          <br />
+        </tal:phone>
+        <tal:email condition="sender/email">
+          <span tal:replace="sender/email">email</span>
+          <br />
+        </tal:email>
+        <tal:web condition="sender/web">
+          <span tal:replace="sender/web">web</span>
+          <br />
+        </tal:web>
       </div>
 
       <div class="invoice_receiver">
-        <span tal:replace="view/gender">gender</span>
         <span tal:replace="order/personal_data.firstname">first name</span>
         <span tal:replace="order/personal_data.lastname">last name</span>
         <br />
@@ -61,14 +68,14 @@
         </span>
       </div>
 
-      <h1 class="invoice_title">
+      <h2 class="invoice_number">
         <span i18n:translate="invoice">Invoice</span>
-        <span tal:replace="view/invoice_number">INV12345<span>
-      </h1>
+        <span tal:replace="view/invoice_number">INV12345</span>
+      </h2>
 
       <span class="invoice_date">
-        <span tal:replace="vendor/city">city</span>,
-        <span tal:replace="python:view.format_date(order['created'])">date</span>
+        <span tal:replace="sender/city">city</span>,
+        <span tal:replace="view/created">date</span>
       </span>
 
     </div>

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -242,17 +242,17 @@
 
   <div class="invoice_bank_connection">
     <strong>IBAN</strong>
-    <span tal:replace="sender/iban">
+    <span tal:replace="sender/iban">IBAN</span>
     <br />
 
     <strong>BIC</strong>
-    <span tal:replace="sender/bic">
+    <span tal:replace="sender/bic">BIC</span>
     <br />
   </div>
 
   <div class="invoice_footer">
     <span i18n:translate="invoice_prices_in_currency">All prices in</span>
-    <span tal:replace="summary/currency">
+    <span tal:replace="summary/currency" />
     <br />
     <br />
     <br />

--- a/src/bda/plone/orders/browser/invoice.pt
+++ b/src/bda/plone/orders/browser/invoice.pt
@@ -56,8 +56,10 @@
         <span tal:replace="order/personal_data.firstname">first name</span>
         <span tal:replace="order/personal_data.lastname">last name</span>
         <br />
-        <span tal:replace="order/personal_data.company">company</span>
-        <br />
+        <tal:company condition="order/personal_data.company">
+          <span tal:replace="order/personal_data.company">company</span>
+          <br />
+        </tal:company>
         <span tal:replace="order/billing_address.street">street</span>
         <br />
         <span tal:replace="order/billing_address.zip">zip</span>
@@ -73,10 +75,56 @@
         <span tal:replace="view/invoice_number">INV12345</span>
       </h2>
 
-      <span class="invoice_date">
+      <h3 class="invoice_date">
         <span tal:replace="sender/city">city</span>,
         <span tal:replace="view/created">date</span>
-      </span>
+      </h3>
+
+      <div class="invoice_listing">
+        <div class="invoice_listing_head">
+          <div class="invoice_listing_amount">
+            <strong i18n:translate="invoice_listing_amount">Amount</strong>
+          </div>
+          <div class="invoice_listing_position">
+            <strong i18n:translate="invoice_listing_position">Position</strong>
+          </div>
+          <div class="invoice_listing_price">
+            <strong i18n:translate="invoice_listing_price">Price</strong>
+          </div>
+        </div>
+
+        <tal:item repeat="item view/listing">
+          <div class="invoice_listing_item">
+            <div class="invoice_listing_amount">
+              <span tal:replace="item/count">count</span>
+              <span tal:replace="item/quantity_unit">quantity</span>
+            </div>
+
+            <div class="invoice_listing_position">
+              <span tal:replace="item/title">title</span>
+              <tal:comment condition="item/comment">
+                (<span tal:replace="item/comment">comment</span>)
+              </tal:comment>
+            </div>
+
+            <div class="invoice_listing_price">
+              <tal:without_discount condition="not:item/discount_net">
+                <tal:price replace="python:view.ascur(item['net'])" />
+                <tal:currency replace="item/currency" />
+              </tal:without_discount>
+
+              <tal:with_discount condition="item/discount_net">
+                <span class="original_price">
+                  <tal:price replace="python:view.ascur(item['net'])" />
+                  <tal:currency replace="item/currency" />
+                </span>
+                <tal:price replace="python:view.ascur(item['net'] - item['discount_net'])" />
+                <tal:currency replace="item/currency" />
+              </tal:with_discount>
+            </div>
+          </div>
+        </tal:item>
+      </div>
 
     </div>
 

--- a/src/bda/plone/orders/browser/invoice_view.pt
+++ b/src/bda/plone/orders/browser/invoice_view.pt
@@ -20,7 +20,7 @@
 <metal:main fill-slot="main">
   <tal:main-macro metal:define-macro="main">
 
-    <tal:invoice replace="structure view/render_invoice_template" />
+    <tal:invoice replace="structure view/render_content" />
 
   </tal:main-macro>
 </metal:main>

--- a/src/bda/plone/orders/browser/invoice_view.pt
+++ b/src/bda/plone/orders/browser/invoice_view.pt
@@ -1,0 +1,29 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="bda.plone.orders">
+
+<head>
+  <metal:override
+    fill-slot="top_slot"
+    tal:define="
+        border view/disable_border;
+        disable_left_column view/disable_left_column;
+        disable_right_column view/disable_right_column" />
+</head>
+
+<body>
+
+<metal:main fill-slot="main">
+  <tal:main-macro metal:define-macro="main">
+
+    <tal:invoice replace="structure view/render_invoice_template" />
+
+  </tal:main-macro>
+</metal:main>
+
+</body>
+</html>

--- a/src/bda/plone/orders/browser/mailtemplates.py
+++ b/src/bda/plone/orders/browser/mailtemplates.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from bda.plone.orders import message_factory as _
-from bda.plone.orders.browser.views import OrdersContentView
+from bda.plone.orders.browser.views import ContentViewBase
 from bda.plone.orders.interfaces import IDynamicMailTemplateLibraryStorage
 from bda.plone.orders.mailtemplates import DEFAULT_TEMPLATE_ATTRS
 from bda.plone.orders.mailtemplates import DynamicMailTemplate
@@ -15,7 +15,7 @@ TEMPLATE = DynamicMailTemplate(
 )
 
 
-class MailtemplatesView(OrdersContentView):
+class MailtemplatesView(ContentViewBase):
 
     def default_attrs(self):
         items = []

--- a/src/bda/plone/orders/browser/order.pt
+++ b/src/bda/plone/orders/browser/order.pt
@@ -2,6 +2,7 @@
      xmlns="http://www.w3.org/1999/xhtml"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+     xmlns:ajax="http://namesspaces.bluedynamics.eu/ajax"
      i18n:domain="bda.plone.orders"
      tal:define="order view/order">
 
@@ -160,7 +161,7 @@
 
   <div class="order_bookings">
     <h3 i18n:translate="order_bookings">Order Bookings:</h3>
-    <table>
+    <table tal:define="resources_url string:${context/absolute_url}/++resource++bda.plone.orders">
       <tal:tr repeat="row view/listing">
         <tal:def define="even repeat/row/even;
                          start repeat/row/start;
@@ -181,7 +182,16 @@
           </tr>
 
           <tr tal:attributes="class python:even and 'even' or 'odd'">
-            <td><a href="row/url" target="_blank" tal:attributes="href row/url" tal:content="row/title">title</a></td>
+            <td>
+              <a href="#"
+                 target="_blank"
+                 tal:attributes="href row/url"
+                 tal:content="row/title"
+                 tal:condition="row/url">title</a>
+
+              <span tal:replace="row/title"
+                    tal:condition="not:row/url">title</span>
+            </td>
             <td tal:content="row/count">count</td>
             <td tal:content="row/quantity_unit">quantity</td>
             <td tal:content="row/currency">EUR</td>
@@ -192,57 +202,63 @@
             </td>
             <td tal:condition="show_exported" tal:content="python:view.exported(row)">No</td>
             <td>
-                <span class="booking_comment_display booking_comment_text"
-                      tal:content="row/comment">comment
-                </span>
-                <input tal:condition="python:view.can_modify_order"
-                       class="booking_comment_edit"
+              <span class="booking_comment_display booking_comment_text"
+                    tal:content="row/comment">comment</span>
+              <tal:edit condition="view/can_modify_order">
+                <input class="booking_comment_edit"
                        type="text"
                        tal:attributes="value row/comment;
                                        data-booking-uid row/uid;
                                        data-edit-url string:${context/absolute_url}/@@booking_update_comment"
                 />
-
-                <a tal:condition="python:view.can_modify_order"
-                    class="booking_comment_display booking_comment_edit_action"
-                    href="#"><img src="#"
-                        title="edit comment"
-                        alt="edit comment icon"
-                        tal:attributes="src string:${context/absolute_url}/++resource++bda.plone.orders/pencil.png"/></a>
-
-                <img tal:condition="python:view.can_modify_order"
-                     class="booking_comment_spinner"
+                <a href="#"
+                   class="booking_comment_display booking_comment_edit_action">
+                  <img src="#"
+                       title="edit comment"
+                       alt="edit comment icon"
+                       tal:attributes="src string:${resources_url}/pencil.png"
+                  />
+                </a>
+                <img class="booking_comment_spinner"
                      src="#"
                      alt="spinner icon"
-                     tal:attributes="src string:${context/absolute_url}/++resource++bda.plone.orders/spinner.gif"/>
-
-                <a tal:condition="python:view.can_modify_order"
-                    class="booking_comment_edit booking_comment_save_action"
-                    href="#"><img
-                        src="#"
-                        title="save comment"
-                        alt="save comment icon"
-                        tal:attributes="src string:${context/absolute_url}/++resource++bda.plone.orders/tick.png"/></a>
-
-                <a tal:condition="python:view.can_modify_order"
-                    class="booking_comment_edit booking_comment_abort_action"
-                    href="#"><img
-                        src="#"
-                        title="undo edit comment"
-                        alt="undo edit comment icon"
-                        tal:attributes="src string:${context/absolute_url}/++resource++bda.plone.orders/cross.png"/></a>
-
+                     tal:attributes="src string:${resources_url}/spinner.gif"
+                />
+                <a href="#"
+                   class="booking_comment_edit booking_comment_save_action">
+                  <img src="#"
+                       title="save comment"
+                       alt="save comment icon"
+                       tal:attributes="src string:${resources_url}/tick.png"
+                  />
+                </a>
+                <a href="#"
+                   class="booking_comment_edit booking_comment_abort_action">
+                  <img src="#"
+                       title="undo edit comment"
+                       alt="undo edit comment icon"
+                       tal:attributes="src string:${resources_url}/cross.png"
+                  />
+                </a>
+              </tal:edit>
             </td>
             <td>
-                <span tal:content="row/state">state</span>
-                <a tal:condition="row/cancel_url"
-                   tal:attributes="href row/cancel_url"
-                   class="booking-cancel-link discreet"
-                   href="#"><img
-                       src="#"
-                       title="cancel booking"
-                       alt="cancel booking"
-                       tal:attributes="src string:${context/absolute_url}/++resource++bda.plone.orders/delete.png" /></a>
+              <span tal:content="row/state">state</span>
+
+              <a href="#"
+                 class="booking-cancel-link discreet"
+                 ajax:bind="click"
+                 ajax:target="#"
+                 ajax:action="booking_cancel:NONE:NONE"
+                 ajax:confirm="Do you really want to cancel this booking?"
+                 tal:attributes="ajax:target row/cancel_target"
+                 tal:condition="row/cancel_target">
+                <img src="#"
+                     title="cancel booking"
+                     alt="cancel booking"
+                     tal:attributes="src string:${resources_url}/delete.png"
+                />
+              </a>
             </td>
             <td tal:content="row/salaried">salaried</td>
           </tr>

--- a/src/bda/plone/orders/browser/protected_view.pt
+++ b/src/bda/plone/orders/browser/protected_view.pt
@@ -6,18 +6,27 @@
       metal:use-macro="here/main_template/macros/master"
       i18n:domain="bda.plone.orders">
 
+<head>
+  <metal:override
+    fill-slot="top_slot"
+    tal:define="
+        border view/disable_border;
+        disable_left_column view/disable_left_column;
+        disable_right_column view/disable_right_column" />
+</head>
+
 <body>
 
 <metal:main fill-slot="main">
   <tal:main-macro metal:define-macro="main">
 
-    <div class="order wrapper">
+    <div tal:attributes="class view/wrapper_css|nothing">
 
       <tal:template condition="not:view/uid"
                     replace="structure view/render_auth_form" />
 
       <tal:template condition="view/uid"
-                    replace="structure view/render_order_template" />
+                    replace="structure view/render_content" />
 
     </div>
 

--- a/src/bda/plone/orders/browser/resources/orders.js
+++ b/src/bda/plone/orders/browser/resources/orders.js
@@ -13,7 +13,6 @@
             orders_notification_binder: orders.notification_binder,
             orders_notification_form_binder: orders.notification_form_binder,
             orders_qr_code_binder: orders.qr_code_binder,
-            cancel_confirm_binder: orders.cancel_confirm_binder,
             comment_edit_binder: orders.comment_edit_binder
         });
         orders.datatable_binder(document);
@@ -23,7 +22,6 @@
         orders.order_select_binder(document);
         orders.notification_binder(document);
         orders.qr_code_binder(document);
-        orders.cancel_confirm_binder(document);
         orders.comment_edit_binder(document);
     });
 
@@ -86,36 +84,25 @@
                                 .bind('change', orders.filter_orders);
         },
 
-        cancel_confirm_binder: function(context) {
-            $('.booking-cancel-link', context).bind('click', function(evt) {
-                evt.preventDefault();
-                var options = {
-                    message: 'Are you sure?',
-                    url: $(this).attr('href')
-                };
-                bdajax.dialog(options, function(options) {
-                    window.location.href = options.url;
-                });
-            });
-        },
-
-        comment_edit_binder: function(event) {
-            $('.booking_comment_edit_action')
+        comment_edit_binder: function(context) {
+            $('.booking_comment_edit', context).hide();
+            $('.booking_comment_edit_action', context)
                 .unbind('click')
                 .bind('click', orders.comment_edit_start);
-            $('.booking_comment_save_action')
+            $('.booking_comment_save_action', context)
                 .unbind('click')
                 .bind('click', orders.comment_edit_save);
-            $('.booking_comment_abort_action')
+            $('.booking_comment_abort_action', context)
                 .unbind('click')
                 .bind('click', orders.comment_edit_abort);
-
         },
+
         comment_edit_start: function(event) {
             event.preventDefault();
             $(this).parent().find('.booking_comment_display').hide();
             $(this).parent().find('.booking_comment_edit').show();
         },
+
         comment_edit_save: function(event) {
             event.preventDefault();
             var parent = $(this).parent();
@@ -142,12 +129,13 @@
                 parent.find('.booking_comment_display').show();
             });
         },
+
         comment_edit_abort: function(event) {
             event.preventDefault();
-            $(this).parent().find('.booking_comment_display').show();
-            $(this).parent().find('.booking_comment_edit').hide();
+            var parent = $(this).parent();
+            parent.find('.booking_comment_display').show();
+            parent.find('.booking_comment_edit').hide();
         },
-
 
         filter_orders: function(event) {
             event.preventDefault();
@@ -247,7 +235,7 @@
             });
         },
 
-        bookings_datatable_binder: function (context) {
+        bookings_datatable_binder: function(context) {
             var url = $('#bdaplonebookings', context).attr('data-ajaxurl');
             // if the table gets called with a hash (this happens on the contacts
             // site) then the table gets initialized via oSearch to only show orders
@@ -342,7 +330,7 @@
             });
         },
 
-        contacts_datatable_binder: function (context) {
+        contacts_datatable_binder: function(context) {
             var url = $('#bdaplonecontacts', context).attr('data-ajaxurl');
             var oTable;
             oTable = $('#bdaplonecontacts', context).DataTable({
@@ -370,7 +358,7 @@
             });
         },
 
-        dropdown_binder: function (context) {
+        dropdown_binder: function(context) {
             var options = {
                 menu: '.dropdown_items',
                 trigger: '.dropdown_header'

--- a/src/bda/plone/orders/browser/resources/orders_p4.css
+++ b/src/bda/plone/orders/browser/resources/orders_p4.css
@@ -120,52 +120,42 @@ a.notify_customers {
     margin-top: 1em;
     margin-bottom: 2.2em;
 }
-
 #bdaplonebookings_length {
     margin-bottom: 0.8em;
 }
-
 #bdaplonebookings_length select,
 #bdaplonebookings_filter input {
     font-size: 90%;
 }
-
 #bdaplonebookings {
     margin-bottom: 1em;
     border: #ddd 1px solid;
 }
-
 #bdaplonebookings_wrapper div.group_filter {
     margin-left: 3em;
 }
-
 #bdaplonebookings_wrapper div.group_filter,
 #bdaplonebookings_wrapper div.date_from_filter,
 #bdaplonebookings_wrapper div.date_to_filter {
     float: left;
     margin-right: 3em;
 }
-
 #bdaplonebookings thead {
     background-color: #fafafa;
 }
-
 #bdaplonebookings th {
     border-right: #ddd 1px solid;
     border-bottom: #ddd 1px solid;
 }
-
 #bdaplonebookings th.datarow-actions {
     width: 120px;
 }
-
 #bdaplonebookings tr.group_email,
 #bdaplonebookings tr.group_email:hover,
 #bdaplonebookings tr.group_buyable,
 #bdaplonebookings tr.group_buyable:hover {
     background-color: #ddd !important;
 }
-
 #bdaplonebookings tr.group_email td p ,
 #bdaplonebookings tr.group_buyable td p{
     margin-bottom: 0;
@@ -173,7 +163,6 @@ a.notify_customers {
     min-width: 18em;
     width: 18em;
 }
-
 #bdaplonebookings tr.group_email span,
 #bdaplonebookings tr.group_buyable span {
     min-width: 18em;
@@ -181,23 +170,18 @@ a.notify_customers {
     float: left;
     margin-left: 7em;
 }
-
 #bdaplonebookings td {
     padding: 1px 3px 1px 10px;
     border-right: #ddd 1px solid;
 }
-
 #bdaplonebookings a.contenttype-document {
     border: none !important;
 }
-
 #bdaplonebookings_paginate a:hover {
     color: #fff !important;
 }
 
 /* end rules for new bookingstable */
-
-
 
 /* export form */
 #field-exportorders-from,
@@ -308,4 +292,25 @@ a.notify_customers {
 }
 .order.wrapper form div.submit input {
     float: right;
+}
+
+/* invoice */
+.invoice .invoice_title {
+    text-align:center;
+}
+.invoice .invoice_sender {
+    width:30%;
+    float:right;
+}
+.invoice .invoice_receiver {
+    clear:both;
+    padding-top:2em;
+    padding-bottom:2em;
+}
+.invoice .invoice_number {
+    float:left;
+}
+.invoice .invoice_date {
+    float:right;
+    margin-top:2.5em;
 }

--- a/src/bda/plone/orders/browser/resources/orders_p4.css
+++ b/src/bda/plone/orders/browser/resources/orders_p4.css
@@ -378,3 +378,9 @@ a.notify_customers {
 .invoice .invoice_summary .red {
     color: red;
 }
+.invoice .invoice_bank_connection {
+    clear:both;
+}
+.invoice .invoice_footer {
+    margin-top:2em;
+}

--- a/src/bda/plone/orders/browser/resources/orders_p4.css
+++ b/src/bda/plone/orders/browser/resources/orders_p4.css
@@ -263,7 +263,6 @@ a.notify_customers {
     width:380px;
     padding:0.4em;
 }
-.booking_comment_edit,
 .booking_comment_spinner {
     display: none;
 }

--- a/src/bda/plone/orders/browser/resources/orders_p4.css
+++ b/src/bda/plone/orders/browser/resources/orders_p4.css
@@ -224,6 +224,28 @@ a.notify_customers {
     color:#e50000;
 }
 
+/* protected order data */
+.protected_order_data form {
+    display: table;
+    border-spacing: 1em;
+}
+.protected_order_data form > div {
+    display: table-row;
+}
+.protected_order_data form label {
+    display: table-cell;
+}
+.protected_order_data form div.error,
+.protected_order_data form input {
+    display: table-cell;
+}
+.protected_order_data form div.submit label {
+    color: transparent;
+}
+.protected_order_data form div.submit input {
+    float: right;
+}
+
 /* order */
 .order_details {
     padding:1.2em;
@@ -272,26 +294,6 @@ a.notify_customers {
 }
 .order_bookings tr.odd td {
     background-color:#fbfbfb;
-}
-.order.wrapper form {
-    display: table;
-    border-spacing: 1em;
-}
-.order.wrapper form > div {
-    display: table-row;
-}
-.order.wrapper form label {
-    display: table-cell;
-}
-.order.wrapper form div.error,
-.order.wrapper form input {
-    display: table-cell;
-}
-.order.wrapper form div.submit label {
-    color: transparent;
-}
-.order.wrapper form div.submit input {
-    float: right;
 }
 
 /* invoice */

--- a/src/bda/plone/orders/browser/resources/orders_p4.css
+++ b/src/bda/plone/orders/browser/resources/orders_p4.css
@@ -309,8 +309,43 @@ a.notify_customers {
 }
 .invoice .invoice_number {
     float:left;
+    margin-bottom:1em;
 }
 .invoice .invoice_date {
     float:right;
-    margin-top:2.5em;
+    margin-top:1.2em;
+}
+.invoice .invoice_listing {
+    clear:both;
+    display:table;
+    border-collapse:collapse;
+    width:100%;
+}
+.invoice .invoice_listing_head {
+    display:table-row;
+    border-top:#333 1px solid;
+    border-bottom:#333 1px solid;
+}
+.invoice .invoice_listing_item {
+    display:table-row;
+    border-bottom:#333 1px solid;
+}
+.invoice .invoice_listing_amount,
+.invoice .invoice_listing_position,
+.invoice .invoice_listing_price {
+    display:table-cell;
+    padding-top:0.3em;
+    padding-bottom:0.3em;
+}
+.invoice .invoice_listing_amount {
+    width: 12%;
+}
+.invoice .invoice_listing_price {
+    text-align:right;
+    width: 24%;
+}
+.invoice .original_price {
+    float:left;
+    color: red;
+    text-decoration: line-through;
 }

--- a/src/bda/plone/orders/browser/resources/orders_p4.css
+++ b/src/bda/plone/orders/browser/resources/orders_p4.css
@@ -349,3 +349,32 @@ a.notify_customers {
     color: red;
     text-decoration: line-through;
 }
+.invoice .invoice_summary {
+    width:30%;
+    float:right;
+    margin-top:2em;
+}
+.invoice .invoice_summary_section {
+    display:table;
+    width:100%;
+    border-bottom:#333 1px solid;
+    padding-top:0.5em;
+    padding-bottom:0.5em;
+}
+.invoice .invoice_summary_row {
+    display:table-row;
+}
+.invoice .invoice_summary_label {
+    display:table-cell;
+    padding-top:0.1em;
+    padding-bottom:0.1em;
+}
+.invoice .invoice_summary_value {
+    display:table-cell;
+    padding-top:0.1em;
+    padding-bottom:0.1em;
+    text-align:right;
+}
+.invoice .invoice_summary .red {
+    color: red;
+}

--- a/src/bda/plone/orders/browser/resources/orders_p5.css
+++ b/src/bda/plone/orders/browser/resources/orders_p5.css
@@ -274,7 +274,6 @@ a.notify_customers {
   width: 380px;
   padding: 0.4em;
 }
-.booking_comment_edit,
 .booking_comment_spinner {
   display: none;
 }

--- a/src/bda/plone/orders/browser/resources/orders_p5.css
+++ b/src/bda/plone/orders/browser/resources/orders_p5.css
@@ -236,6 +236,27 @@ a.notify_customers {
 .salaried-value-failed {
   color: #e50000;
 }
+/* protected order data */
+.protected_order_data form {
+  display: table;
+  border-spacing: 1em;
+}
+.protected_order_data form > div {
+  display: table-row;
+}
+.protected_order_data form label {
+  display: table-cell;
+}
+.protected_order_data form div.error,
+.protected_order_data form input {
+  display: table-cell;
+}
+.protected_order_data form div.submit label {
+  color: transparent;
+}
+.protected_order_data form div.submit input {
+  float: right;
+}
 /* order */
 .order_details {
   padding: 1.2em;
@@ -292,27 +313,6 @@ input[type="text"].booking_comment_edit {
 .order_bookings tr.odd td {
   background-color: #fbfbfb;
 }
-.order.wrapper form {
-  display: table;
-  border-spacing: 1em;
-}
-.order.wrapper form > div {
-  display: table-row;
-}
-.order.wrapper form label {
-  display: table-cell;
-}
-.order.wrapper form div.error,
-.order.wrapper form input {
-  display: table-cell;
-}
-.order.wrapper form div.submit label {
-  color: transparent;
-}
-.order.wrapper form div.submit input {
-  float: right;
-}
-
 /* invoice */
 .invoice .invoice_title {
   text-align:center;
@@ -403,7 +403,6 @@ input[type="text"].booking_comment_edit {
 .invoice .invoice_footer {
   margin-top:2em;
 }
-
 /* print styles */
 @media print {
   /* rules for bookingstable  print preview */

--- a/src/bda/plone/orders/browser/resources/orders_p5.css
+++ b/src/bda/plone/orders/browser/resources/orders_p5.css
@@ -397,6 +397,12 @@ input[type="text"].booking_comment_edit {
 .invoice .invoice_summary .red {
   color: red;
 }
+.invoice .invoice_bank_connection {
+  clear:both;
+}
+.invoice .invoice_footer {
+  margin-top:2em;
+}
 
 /* print styles */
 @media print {

--- a/src/bda/plone/orders/browser/resources/orders_p5.css
+++ b/src/bda/plone/orders/browser/resources/orders_p5.css
@@ -328,10 +328,45 @@ input[type="text"].booking_comment_edit {
 }
 .invoice .invoice_number {
   float:left;
+  margin-bottom:1em;
 }
 .invoice .invoice_date {
   float:right;
-  margin-top:2.5em;
+  margin-top:1.2em;
+}
+.invoice .invoice_listing {
+  clear:both;
+  display:table;
+  border-collapse:collapse;
+  width:100%;
+}
+.invoice .invoice_listing_head {
+  display:table-row;
+  border-top:#333 1px solid;
+  border-bottom:#333 1px solid;
+}
+.invoice .invoice_listing_item {
+  display:table-row;
+  border-bottom:#333 1px solid;
+}
+.invoice .invoice_listing_amount,
+.invoice .invoice_listing_position,
+.invoice .invoice_listing_price {
+  display:table-cell;
+  padding-top:0.3em;
+  padding-bottom:0.3em;
+}
+.invoice .invoice_listing_amount {
+  width: 12%;
+}
+.invoice .invoice_listing_price {
+  text-align:right;
+  width: 24%;
+}
+.invoice .original_price {
+  float:left;
+  color: red;
+  text-decoration: line-through;
 }
 
 /* print styles */

--- a/src/bda/plone/orders/browser/resources/orders_p5.css
+++ b/src/bda/plone/orders/browser/resources/orders_p5.css
@@ -368,6 +368,35 @@ input[type="text"].booking_comment_edit {
   color: red;
   text-decoration: line-through;
 }
+.invoice .invoice_summary {
+  width:30%;
+  float:right;
+  margin-top:2em;
+}
+.invoice .invoice_summary_section {
+  display:table;
+  width:100%;
+  border-bottom:#333 1px solid;
+  padding-top:0.5em;
+  padding-bottom:0.5em;
+}
+.invoice .invoice_summary_row {
+  display:table-row;
+}
+.invoice .invoice_summary_label {
+  display:table-cell;
+  padding-top:0.1em;
+  padding-bottom:0.1em;
+}
+.invoice .invoice_summary_value {
+  display:table-cell;
+  padding-top:0.1em;
+  padding-bottom:0.1em;
+  text-align:right;
+}
+.invoice .invoice_summary .red {
+  color: red;
+}
 
 /* print styles */
 @media print {

--- a/src/bda/plone/orders/browser/resources/orders_p5.css
+++ b/src/bda/plone/orders/browser/resources/orders_p5.css
@@ -312,6 +312,28 @@ input[type="text"].booking_comment_edit {
 .order.wrapper form div.submit input {
   float: right;
 }
+
+/* invoice */
+.invoice .invoice_title {
+  text-align:center;
+}
+.invoice .invoice_sender {
+  width:30%;
+  float:right;
+}
+.invoice .invoice_receiver {
+  clear:both;
+  padding-top:2em;
+  padding-bottom:2em;
+}
+.invoice .invoice_number {
+  float:left;
+}
+.invoice .invoice_date {
+  float:right;
+  margin-top:2.5em;
+}
+
 /* print styles */
 @media print {
   /* rules for bookingstable  print preview */

--- a/src/bda/plone/orders/browser/resources/orders_p5.less
+++ b/src/bda/plone/orders/browser/resources/orders_p5.less
@@ -287,7 +287,6 @@ a.notify_customers {
     width:380px;
     padding:0.4em;
 }
-.booking_comment_edit,
 .booking_comment_spinner {
     display: none;
 }

--- a/src/bda/plone/orders/browser/resources/orders_p5.less
+++ b/src/bda/plone/orders/browser/resources/orders_p5.less
@@ -340,10 +340,45 @@ input[type="text"].booking_comment_edit {
 }
 .invoice .invoice_number {
     float:left;
+    margin-bottom:1em;
 }
 .invoice .invoice_date {
     float:right;
-    margin-top:2.5em;
+    margin-top:1.2em;
+}
+.invoice .invoice_listing {
+    clear:both;
+    display:table;
+    border-collapse:collapse;
+    width:100%;
+}
+.invoice .invoice_listing_head {
+    display:table-row;
+    border-top:#333 1px solid;
+    border-bottom:#333 1px solid;
+}
+.invoice .invoice_listing_item {
+    display:table-row;
+    border-bottom:#333 1px solid;
+}
+.invoice .invoice_listing_amount,
+.invoice .invoice_listing_position,
+.invoice .invoice_listing_price {
+    display:table-cell;
+    padding-top:0.3em;
+    padding-bottom:0.3em;
+}
+.invoice .invoice_listing_amount {
+    width: 12%;
+}
+.invoice .invoice_listing_price {
+    text-align:right;
+    width: 24%;
+}
+.invoice .original_price {
+    float:left;
+    color: red;
+    text-decoration: line-through;
 }
 
 /* print styles */

--- a/src/bda/plone/orders/browser/resources/orders_p5.less
+++ b/src/bda/plone/orders/browser/resources/orders_p5.less
@@ -409,6 +409,12 @@ input[type="text"].booking_comment_edit {
 .invoice .invoice_summary .red {
     color: red;
 }
+.invoice .invoice_bank_connection {
+    clear:both;
+}
+.invoice .invoice_footer {
+    margin-top:2em;
+}
 
 /* print styles */
 @media print {

--- a/src/bda/plone/orders/browser/resources/orders_p5.less
+++ b/src/bda/plone/orders/browser/resources/orders_p5.less
@@ -248,6 +248,28 @@ a.notify_customers {
     color:#e50000;
 }
 
+/* protected order data */
+.protected_order_data form {
+    display: table;
+    border-spacing: 1em;
+}
+.protected_order_data form > div {
+    display: table-row;
+}
+.protected_order_data form label {
+    display: table-cell;
+}
+.protected_order_data form div.error,
+.protected_order_data form input {
+    display: table-cell;
+}
+.protected_order_data form div.submit label {
+    color: transparent;
+}
+.protected_order_data form div.submit input {
+    float: right;
+}
+
 /* order */
 .order_details {
     padding:1.2em;
@@ -303,26 +325,6 @@ input[type="text"].booking_comment_edit {
 }
 .order_bookings tr.odd td {
     background-color:#fbfbfb;
-}
-.order.wrapper form {
-    display: table;
-    border-spacing: 1em;
-}
-.order.wrapper form > div {
-    display: table-row;
-}
-.order.wrapper form label {
-    display: table-cell;
-}
-.order.wrapper form div.error,
-.order.wrapper form input {
-    display: table-cell;
-}
-.order.wrapper form div.submit label {
-    color: transparent;
-}
-.order.wrapper form div.submit input {
-    float: right;
 }
 
 /* invoice */

--- a/src/bda/plone/orders/browser/resources/orders_p5.less
+++ b/src/bda/plone/orders/browser/resources/orders_p5.less
@@ -380,6 +380,35 @@ input[type="text"].booking_comment_edit {
     color: red;
     text-decoration: line-through;
 }
+.invoice .invoice_summary {
+    width:30%;
+    float:right;
+    margin-top:2em;
+}
+.invoice .invoice_summary_section {
+    display:table;
+    width:100%;
+    border-bottom:#333 1px solid;
+    padding-top:0.5em;
+    padding-bottom:0.5em;
+}
+.invoice .invoice_summary_row {
+    display:table-row;
+}
+.invoice .invoice_summary_label {
+    display:table-cell;
+    padding-top:0.1em;
+    padding-bottom:0.1em;
+}
+.invoice .invoice_summary_value {
+    display:table-cell;
+    padding-top:0.1em;
+    padding-bottom:0.1em;
+    text-align:right;
+}
+.invoice .invoice_summary .red {
+    color: red;
+}
 
 /* print styles */
 @media print {

--- a/src/bda/plone/orders/browser/resources/orders_p5.less
+++ b/src/bda/plone/orders/browser/resources/orders_p5.less
@@ -76,7 +76,6 @@
     display: unset;
 }
 
-
 /* orders */
 #bdaploneorders_wrapper {
     margin-top:1em;
@@ -85,7 +84,6 @@
 #bdaploneorders_length {
     margin-bottom:0.8em;
 }
-
 #bdaploneorders_length select,
 #bdaploneorders_filter input {
     font-size:90%;
@@ -146,52 +144,42 @@ a.notify_customers {
     margin-top: 1em;
     margin-bottom: 2.2em;
 }
-
 #bdaplonebookings_length {
     margin-bottom: 0.8em;
 }
-
 #bdaplonebookings_length select,
 #bdaplonebookings_filter input {
     font-size: 90%;
 }
-
 #bdaplonebookings {
     margin-bottom: 1em;
     border: #ddd 1px solid;
 }
-
 #bdaplonebookings_wrapper div.group_filter {
     margin-left: 3em;
 }
-
 #bdaplonebookings_wrapper div.group_filter,
 #bdaplonebookings_wrapper div.date_from_filter,
 #bdaplonebookings_wrapper div.date_to_filter {
     float: left;
     margin-right: 3em;
 }
-
 #bdaplonebookings thead {
     background-color: #fafafa;
 }
-
 #bdaplonebookings th {
     border-right: #ddd 1px solid;
     border-bottom: #ddd 1px solid;
 }
-
 #bdaplonebookings th.datarow-actions {
     width: 120px;
 }
-
 #bdaplonebookings tr.group_email,
 #bdaplonebookings tr.group_email:hover,
 #bdaplonebookings tr.group_buyable,
 #bdaplonebookings tr.group_buyable:hover {
     background-color: #ddd !important;
 }
-
 #bdaplonebookings tr.group_email td p ,
 #bdaplonebookings tr.group_buyable td p{
     margin-bottom: 0;
@@ -199,7 +187,6 @@ a.notify_customers {
     min-width: 18em;
     width: 18em;
 }
-
 #bdaplonebookings tr.group_email span,
 #bdaplonebookings tr.group_buyable span {
     min-width: 18em;
@@ -207,23 +194,18 @@ a.notify_customers {
     float: left;
     margin-left: 7em;
 }
-
 #bdaplonebookings td {
     padding: 1px 3px 1px 10px;
     border-right: #ddd 1px solid;
 }
-
 #bdaplonebookings a.contenttype-document {
     border: none !important;
 }
-
 #bdaplonebookings_paginate a:hover {
     color: #fff !important;
 }
 
 /* end rules for new bookingstable */
-
-
 
 /* export form */
 #field-exportorders-from,
@@ -343,15 +325,35 @@ input[type="text"].booking_comment_edit {
     float: right;
 }
 
+/* invoice */
+.invoice .invoice_title {
+    text-align:center;
+}
+.invoice .invoice_sender {
+    width:30%;
+    float:right;
+}
+.invoice .invoice_receiver {
+    clear:both;
+    padding-top:2em;
+    padding-bottom:2em;
+}
+.invoice .invoice_number {
+    float:left;
+}
+.invoice .invoice_date {
+    float:right;
+    margin-top:2.5em;
+}
+
 /* print styles */
 @media print {
-    /* rules for bookingstable  print preview */
+    /* rules for bookingstable - print preview */
     #bookings_wrapper .customfilter label,
     #bookings_wrapper #bdaplonebookings_filter label,
     #bookings_wrapper #bdaplonebookings_length label {
         font-weight: bold;
     }
-
     #bookings_wrapper .customfilter input,
     #bookings_wrapper #bdaplonebookings_filter input,
     #bookings_wrapper #bdaplonebookings_length select,
@@ -360,55 +362,44 @@ input[type="text"].booking_comment_edit {
         background: transparent;
         margin-left: 3em;
     }
-
     #bdaplonebookings_wrapper {
         margin-top: 1em;
         margin-bottom: 2.2em;
     }
-
     #bdaplonebookings_length {
         margin-bottom: 0.8em;
     }
-
     #bdaplonebookings_length select,
     #bdaplonebookings_filter input {
         font-size: 90%;
     }
-
     #bdaplonebookings {
         margin-bottom: 1em;
         border: #ddd 1px solid;
     }
-
     #bdaplonebookings_wrapper div.group_filter {
         margin-left: 3em;
     }
-
     #bdaplonebookings_wrapper div.group_filter,
     #bdaplonebookings_wrapper div.date_from_filter,
     #bdaplonebookings_wrapper div.date_to_filter {
         float: left;
         margin-right: 3em;
     }
-
     #bdaplonebookings thead {
         background-color: #fafafa;
     }
-
     #bdaplonebookings th {
         border-right: #ddd 1px solid;
         border-bottom: #ddd 1px solid;
     }
-
     #bdaplonebookings th.datarow-actions {
         width: 120px;
     }
-
     #bdaplonebookings tr.group_email,
     #bdaplonebookings tr.group_buyable {
         background-color: #ddd !important;
     }
-
     #bdaplonebookings tr.group_email td p,
     #bdaplonebookings tr.group_buyable td p {
         margin-top: 0;
@@ -417,7 +408,6 @@ input[type="text"].booking_comment_edit {
         min-width: 18em;
         width: 18em;
     }
-
     #bdaplonebookings tr.group_email span,
     #bdaplonebookings tr.group_buyable span {
         min-width: 18em;
@@ -425,16 +415,13 @@ input[type="text"].booking_comment_edit {
         float: left;
         margin-left: 7em;
     }
-
     #bdaplonebookings td {
         padding: 1px 3px 1px 10px;
         border-right: #ddd 1px solid;
     }
-
     #bdaplonebookings a.contenttype-document {
         border: none !important;
     }
-
     #bdaplonebookings_paginate {
         display: none;
     }

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -1042,7 +1042,9 @@ class InvoiceViewBase(OrderDataView):
             'country': u'040',
             'phone': u'+43 123 123 123 123',
             'email': u'max.mustermann@example.com',
-            'web': u'www.example.com'
+            'web': u'www.example.com',
+            'iban': u'AT00 0000 0000 0000 0000',
+            'bic': u'XXXXXXXX',
         }
 
     @property

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -1073,6 +1073,30 @@ class InvoiceViewBase(OrderDataView):
             ret.append(data)
         return ret
 
+    def summary(self):
+        order_data = self.order_data
+        data = dict()
+        data['currency'] = order_data.currency
+        cart_net = order_data.net
+        data['cart_net'] = cart_net
+        cart_vat = order_data.vat
+        data['cart_vat'] = cart_vat
+        discount_net = order_data.discount_net
+        data['discount_net'] = discount_net
+        discount_vat = order_data.discount_vat
+        data['discount_vat'] = discount_vat
+        discount_total = discount_net + discount_vat
+        data['discount_total'] = discount_total
+        shipping_net = order_data.shipping_net
+        data['shipping_net'] = shipping_net
+        shipping_vat = order_data.shipping_vat
+        data['shipping_vat'] = shipping_vat
+        shipping_total = shipping_net + shipping_vat
+        data['shipping_total'] = shipping_total
+        cart_total = order_data.total
+        data['cart_total'] = cart_total
+        return data
+
     def ascur(self, val):
         return ascur(val)
 

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -973,6 +973,22 @@ class DirectOrderView(OrderViewBase):
         return self.order_auth_template(self)
 
 
+class InvoiceViewBase(OrderViewBase):
+    pass
+
+
+class InvoiceView(InvoiceViewBase):
+    pass
+
+
+class MyInvoiceView(InvoiceViewBase):
+    pass
+
+
+class DirectInvoiceView(InvoiceViewBase):
+    pass
+
+
 class OrderDone(BrowserView):
     # XXX: provide different headings and texts for states reservation and
     #      mixed

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -54,6 +54,8 @@ IS_P4 = pkg_resources.require("Products.CMFPlone")[0].version[0] == '4'
 
 
 class OrdersContentView(BrowserView):
+    """Base view class for content views.
+    """
 
     def disable_border(self):
         if IS_P4:
@@ -1019,7 +1021,8 @@ class DirectOrderView(OrderViewBase):
         return self.order_auth_template(self)
 
 
-class InvoiceView(OrderDataView):
+class InvoiceViewBase(OrderDataView):
+    invoice_template = ViewPageTemplateFile('invoice.pt')
     invoice_prefix = u'INV'
 
     @property
@@ -1104,9 +1107,21 @@ class InvoiceView(OrderDataView):
     def ascur(self, val):
         return ascur(val)
 
+    def render_invoice_template(self):
+        return self.invoice_template(self)
+
+
+class InvoiceView(InvoiceViewBase, OrdersContentView):
+    pass
+
 
 class DirectInvoiceView(InvoiceView):
     pass
+
+    # XXX: this view
+    # XXX: i18n
+    # XXX: icons in orders view
+    # XXX: booking billable
 
 
 class OrderDone(BrowserView):

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -974,7 +974,27 @@ class DirectOrderView(OrderViewBase):
 
 
 class InvoiceViewBase(OrderViewBase):
-    pass
+    invoice_prefix = u'INV'
+
+    @property
+    def vendor(self):
+        return {
+            'title': u'Vendor name',
+            'subtitle': u'Vendor description',
+            'firstname': u'Max',
+            'lastname': u'Mustermann',
+            'street': u'Musterstrasse 1',
+            'zip': u'1234',
+            'city': u'Musterort',
+            'country': u'at',
+            'phone': u'+43 123 123 123 123',
+            'email': u'max.mustermann@example.com',
+            'web': u'www.example.com'
+        }
+
+    @property
+    def invoice_number(self):
+        return '{}{}'.format(self.invoice_prefix, self.order['ordernumber'])
 
 
 class InvoiceView(InvoiceViewBase):

--- a/src/bda/plone/orders/browser/views.py
+++ b/src/bda/plone/orders/browser/views.py
@@ -24,6 +24,7 @@ from bda.plone.orders.common import get_vendor_by_uid
 from bda.plone.orders.common import get_vendor_uids_for
 from bda.plone.orders.common import get_vendors_for
 from bda.plone.orders.interfaces import IBuyable
+from bda.plone.orders.interfaces import IInvoiceSender
 from bda.plone.orders.transitions import do_transition_for
 from bda.plone.orders.transitions import transitions_of_main_state
 from bda.plone.orders.transitions import transitions_of_salaried_state
@@ -1018,7 +1019,7 @@ class DirectOrderView(OrderViewBase):
         return self.order_auth_template(self)
 
 
-class InvoiceViewBase(OrderDataView):
+class InvoiceView(OrderDataView):
     invoice_prefix = u'INV'
 
     @property
@@ -1031,20 +1032,21 @@ class InvoiceViewBase(OrderDataView):
         #      point even if there are multiple vendors for one order the
         #      global sender address is used (which is actually the current
         #      and only behavior).
+        sender = IInvoiceSender(self.context)
         return {
-            'title': u'Vendor name',
-            'subtitle': u'Vendor description',
-            'firstname': u'Max',
-            'lastname': u'Mustermann',
-            'street': u'Musterstrasse 1',
-            'zip': u'1234',
-            'city': u'Musterort',
-            'country': u'040',
-            'phone': u'+43 123 123 123 123',
-            'email': u'max.mustermann@example.com',
-            'web': u'www.example.com',
-            'iban': u'AT00 0000 0000 0000 0000',
-            'bic': u'XXXXXXXX',
+            'company': sender.company,
+            'companyadd': sender.companyadd,
+            'firstname': sender.firstname,
+            'lastname': sender.lastname,
+            'street': sender.street,
+            'zip': sender.zip,
+            'city': sender.city,
+            'country': sender.country,
+            'phone': sender.phone,
+            'email': sender.email,
+            'web': sender.web,
+            'iban': sender.iban,
+            'bic': sender.bic
         }
 
     @property
@@ -1103,15 +1105,7 @@ class InvoiceViewBase(OrderDataView):
         return ascur(val)
 
 
-class InvoiceView(InvoiceViewBase):
-    pass
-
-
-class MyInvoiceView(InvoiceViewBase):
-    pass
-
-
-class DirectInvoiceView(InvoiceViewBase):
+class DirectInvoiceView(InvoiceView):
     pass
 
 

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -466,15 +466,39 @@ class OrderCheckoutAdapter(CheckoutAdapter):
         return booking
 
 
+# Patch this tuple with booking states which should be ignored at initial
+# billing.
+# WARNING: see notes in ``is_billable_booking`` docs.
+BOOKING_BILLABLE_IGNORE_STATES = tuple()
+
+
 def is_billable_booking(booking):
     """Return True, if booking is billable and should be included in order
     summary calculations.
-    To be used in Pythons filter function::
+
+    To be used in Pythons filter function:
+
         filter(is_billable_booking, bookings)
+
+    WARNING:
+
+    This function has been added for bda.plone.ticketshop to skip billing
+    sold out tickets. When selling tickets, a backorder is handled that
+    someone waits until a ticket order from another customer gets cancelled.
+
+    But this behavior does not apply to most shop implementations where goods
+    are sold. Here a backorder normally means a temporary unavailability of
+    buyable items and has effect to delivery time, not billing.
+
+    Since bda.plone.orders does not properly implement the full UI to handle
+    partly billed bookings (carry back unbilled backorders, incomplete order
+    and invoive views), this function is treated as hack, but is not removed
+    due to the needs of ticketshop unless the related usecase is properly
+    implemented.
+
+    See https://github.com/bluedynamics/bda.plone.orders/issues/45
     """
-    return booking.attrs['state'] not in (
-        ifaces.STATE_RESERVED, ifaces.STATE_CANCELLED
-    )
+    return booking.attrs['state'] not in BOOKING_BILLABLE_IGNORE_STATES
 
 
 def _calculate_order_attr_from_bookings(bookings, attr, mixed_value):

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -352,6 +352,9 @@ class OrderCheckoutAdapter(CheckoutAdapter):
         order.attrs['buyable_uids'] = buyable_uids
         order.attrs['vendor_uids'] = list(vendor_uids)
         # cart discount related information
+        # XXX: in order to be able to reliably modify orders, cart discount
+        #      rules for this order must be stored instead of the actual
+        #      calculated discount.
         cart_discount = cart_data.discount(self.items)
         order.attrs['cart_discount_net'] = cart_discount['net']
         order.attrs['cart_discount_vat'] = cart_discount['vat']
@@ -444,6 +447,9 @@ class OrderCheckoutAdapter(CheckoutAdapter):
         booking.attrs['title'] = brain and brain.Title or 'unknown'
         booking.attrs['net'] = item_data.net
         booking.attrs['vat'] = item_data.vat
+        # XXX: in order to be able to reliably modify bookings, item discount
+        #      rules for this booking must be stored instead of the actual
+        #      calculated discount.
         booking.attrs['discount_net'] = item_data.discount_net(count)
         booking.attrs['currency'] = cart_data.currency
         booking.attrs['quantity_unit'] = item_data.quantity_unit

--- a/src/bda/plone/orders/common.py
+++ b/src/bda/plone/orders/common.py
@@ -52,6 +52,7 @@ logger = logging.getLogger('bda.plone.checkout')
 
 
 DT_FORMAT = '%d.%m.%Y %H:%M'
+DT_FORMAT_SHORT = '%d.%m.%Y'
 
 
 def create_ordernumber():

--- a/src/bda/plone/orders/interfaces.py
+++ b/src/bda/plone/orders/interfaces.py
@@ -171,3 +171,34 @@ class IStockThresholdReached(Interface):
 
     stock_threshold_reached_items = Attribute(u"List of items that are "
                                               u"getting out of stock.")
+
+
+class IInvoiceSender(Interface):
+    """Interface for providing invoice sender.
+    """
+
+    company = Attribute(u"Sender company name")
+
+    companyadd = Attribute(u"Optional Company additional text line")
+
+    firstname = Attribute(u"Sender first name")
+
+    lastname = Attribute(u"Sender last name")
+
+    street = Attribute(u"Streetg")
+
+    zip = Attribute(u"ZIP")
+
+    city = Attribute(u"City")
+
+    country = Attribute(u"Country")
+
+    phone = Attribute(u"Optional phone number")
+
+    email = Attribute(u"Optional email address")
+
+    web = Attribute(u"Optional web address")
+
+    iban = Attribute(u"Banking connection IBAN")
+
+    bic = Attribute(u"Banking connection BIC")

--- a/src/bda/plone/orders/locales/bda.plone.orders.pot
+++ b/src/bda/plone/orders/locales/bda.plone.orders.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr ""
 
@@ -24,8 +24,8 @@ msgid "Item"
 msgstr ""
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr ""
 
@@ -35,37 +35,37 @@ msgid "address"
 msgstr ""
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr ""
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr ""
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr ""
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr ""
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr ""
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr ""
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr ""
 
@@ -179,7 +179,7 @@ msgid "cancelled"
 msgstr ""
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgid "customers_notified_success"
 msgstr ""
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr ""
 
@@ -219,13 +219,13 @@ msgstr ""
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr ""
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr ""
 
@@ -250,25 +250,25 @@ msgstr ""
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr ""
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr ""
 
@@ -294,8 +294,8 @@ msgstr ""
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr ""
 
@@ -352,6 +352,81 @@ msgstr ""
 msgid "inconsistent_currencies"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr ""
@@ -370,8 +445,8 @@ msgstr ""
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr ""
 
@@ -417,18 +492,18 @@ msgid "new"
 msgstr ""
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr ""
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr ""
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr ""
 
@@ -438,12 +513,12 @@ msgid "no_template_selected"
 msgstr ""
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr ""
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr ""
 
@@ -492,7 +567,7 @@ msgid "order_discount_vat"
 msgstr ""
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr ""
 
@@ -805,62 +880,62 @@ msgid "order_summary"
 msgstr ""
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr ""
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr ""
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr ""
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr ""
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr ""
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr ""
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr ""
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr ""
 
@@ -925,12 +1000,12 @@ msgid "renew"
 msgstr ""
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr ""
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr ""
 
@@ -941,12 +1016,12 @@ msgstr ""
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr ""
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr ""
 
@@ -956,12 +1031,12 @@ msgstr ""
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr ""
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1028,19 +1103,19 @@ msgid "transaction_id"
 msgstr ""
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr ""
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr ""
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr ""
 
@@ -1049,24 +1124,34 @@ msgid "vendor_filter"
 msgstr ""
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr ""
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr ""
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
+msgstr ""
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
 msgstr ""
 
 #. Default: "Your Order number"

--- a/src/bda/plone/orders/locales/bda.plone.orders.pot
+++ b/src/bda/plone/orders/locales/bda.plone.orders.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -587,7 +587,7 @@ msgid "order_gender"
 msgstr ""
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -612,22 +612,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -639,17 +639,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -661,47 +661,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -718,7 +723,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -730,17 +735,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -760,27 +765,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -790,17 +795,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/de/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/de/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: 2016-11-02 11:58+0100\n"
 "Last-Translator: Jens W. Klein <jk@kleinundpartner.at>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr "Buchung abgebrochen"
 
@@ -26,8 +26,8 @@ msgid "Item"
 msgstr "Artikel"
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr "Aktionen"
 
@@ -37,37 +37,37 @@ msgid "address"
 msgstr "Adresse"
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr "Alle"
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr "Bitte geben Sie die E-Mail Adresse an unter der Sie die Bestellung abgeschlossen haben."
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr "Keine Bestellung zu den angegebenen Kriterien gefunden."
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr "Bitte geben Sie die Bestellnummer an."
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr "E-Mail"
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr "Bestellnummer"
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr "Absenden"
 
@@ -181,7 +181,7 @@ msgid "cancelled"
 msgstr "Storniert"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "Ort"
 
@@ -210,7 +210,7 @@ msgid "customers_notified_success"
 msgstr "E-Mail an Kunden versandt"
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Datum"
 
@@ -221,13 +221,13 @@ msgstr "Lieferadresse:"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr "E-Mail"
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr "Benachrichtigung an ${receiver} konnte nicht versandt werden."
 
@@ -252,37 +252,37 @@ msgstr "Fehlgeschlagen"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr "Filter nach Kunden"
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
-msgstr ""
+msgstr "Filter nach Bezahlt Status"
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
-msgstr ""
+msgstr "Filter nach Status"
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr "Filter nach Anbieter"
 
 #. Default: "Filter from date"
 #: ./browser/bookings.py:213
 msgid "filter_from_date"
-msgstr ""
+msgstr "Filter Von-Datum"
 
 #. Default: "Filter to date"
 #: ./browser/bookings.py:226
 msgid "filter_to_date"
-msgstr ""
+msgstr "Filter Bis-Datum"
 
 #. Default: "Finish"
 #: ./vocabularies.py:31
@@ -296,8 +296,8 @@ msgstr "Abgeschlossen"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "Vorname"
 
@@ -355,6 +355,81 @@ msgstr "Benutze Platzhalter:"
 msgid "inconsistent_currencies"
 msgstr "Inkonsistente Währung für diese Bestellung. Kontrollieren Sie bitte den Geld- und Warenfluss!"
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr "Rechnung"
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr "Netto"
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr "Rechnungsbetrag"
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr "USt"
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr "Rabatt Netto"
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr "Rabatt Gesamt"
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr "Rabatt USt"
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr "Mit freundlichen Grüßen"
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr "Anzahl"
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr "Position"
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr "Preis"
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr "Alle Preisangaben verstehen sich in"
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr "Versand Netto"
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr "Versand Gesamt"
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr "Versand USt"
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr "Vorlagenbibliothek"
@@ -373,8 +448,8 @@ msgstr "Titel"
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Nachname"
 
@@ -420,18 +495,18 @@ msgid "new"
 msgstr "Neu"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "Nein"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr "Keine Bezahlmethode"
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr "Keine Versandmethode"
 
@@ -441,12 +516,12 @@ msgid "no_template_selected"
 msgstr "Keine Vorlage ausgewählt"
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "Keine"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr "Ausgewählte Kunden benachrichtigen"
 
@@ -495,7 +570,7 @@ msgid "order_discount_vat"
 msgstr "Rabatt MwSt.:"
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr "Bestellung abgeschlossen"
 
@@ -808,62 +883,62 @@ msgid "order_summary"
 msgstr "Zusammenfassung:"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr "Netto: ${value} ${currency}"
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr "Gesamt: ${value} ${currency}"
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr "MwSt.: ${value} ${currency}"
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr "Rabatt Netto: ${value} ${currency}"
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr "Rabatt Gesamt: ${value} ${currency}"
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr "Rabatt MwSt.: ${value} ${currency}"
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr "Zusammenfassung:"
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr "Versand: ${label}"
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr "Versand Netto: ${value} ${currency}"
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr "Versand Gesamt: ${value} ${currency}"
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr "Versand MwSt.: ${value} ${currency}"
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr "Viele Dank für Ihre Bestellung."
 
@@ -928,12 +1003,12 @@ msgid "renew"
 msgstr "auf neu setzen"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr "Reservierung eingelangt"
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr "Vielen Dank für Ihre Reservierung"
 
@@ -944,12 +1019,12 @@ msgstr "Reserviert"
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Bezahlt"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr "Alle sichtbaren Bestellungen auswählen"
 
@@ -959,14 +1034,14 @@ msgstr "Senden"
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "Status"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
-msgstr ""
+msgstr "Information über Bestallung kann nich angezeigt werden. Keine Bestellungs-ID gefunden."
 
 # subject
 msgid "subject"
@@ -1032,19 +1107,19 @@ msgid "transaction_id"
 msgstr "Transaktions ID:"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "unbekannt"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr "Unbekannte Bestellung"
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr "Entschuldigen Sie bitte, Diese Bestellung existiert nicht."
 
@@ -1053,25 +1128,35 @@ msgid "vendor_filter"
 msgstr "Anbieter"
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr "Buchungen ansehen"
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr "Rechnung anzeigen"
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "Bestellung ansehen"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr "Bestellungen ansehen"
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Ja"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr "Ihre Rechnung"
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/locales/de/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/de/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: 2016-11-02 11:58+0100\n"
 "Last-Translator: Jens W. Klein <jk@kleinundpartner.at>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -590,7 +590,7 @@ msgid "order_gender"
 msgstr "Anrede:"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr "Adresse"
 
@@ -615,22 +615,22 @@ msgid "order_mail_cancelled_item"
 msgstr "Stornierter Artikel"
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr "Netto"
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr "Gesamt"
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr "UST"
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr "Stadt"
 
@@ -642,17 +642,17 @@ msgid "order_mail_click_here"
 msgstr "Hier klicken"
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr "Kommentar"
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr "Firma"
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr "Land"
 
@@ -664,47 +664,52 @@ msgid "order_mail_date"
 msgstr "Datum"
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr "Lieferadresse"
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr "Rabatt Netto"
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr "Rabatt Gesamt"
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr "Rabatt UST"
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr "E-Mail"
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr "Name"
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr "Rechnung"
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr "Artikelnummer"
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr "Preis"
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr "Anmerkungen"
 
@@ -721,7 +726,7 @@ msgid "order_mail_order_heading"
 msgstr "Besten Dank für Ihre Bestellung!"
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr "Bestellte Artikel"
 
@@ -733,17 +738,17 @@ msgid "order_mail_ordernumber"
 msgstr "Bestellungsnummer"
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr "Bezahlung"
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr "Persönliche Angaben"
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr "Telefon"
 
@@ -763,27 +768,27 @@ msgid "order_mail_reservation_heading"
 msgstr "Besten Dank für Ihre Reservierung!"
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr "Reservierte Artikel"
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr "Versand"
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr "Versand Netto"
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr "Versand Gesamt"
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr "Versand UST"
 
@@ -793,17 +798,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr "Artikel erreichen niedrigen Lagerbestand"
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr "Straße"
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr "Zusammenfassung"
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr "PLZ"
 

--- a/src/bda/plone/orders/locales/en/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/en/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Peter Holzer <hpeter@agitator.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -588,7 +588,7 @@ msgid "order_gender"
 msgstr "Gender:"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -613,22 +613,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -640,17 +640,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -662,47 +662,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -719,7 +724,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -731,17 +736,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -761,27 +766,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -791,17 +796,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/en/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/en/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Peter Holzer <hpeter@agitator.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: bda.plone.orders\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr ""
 
@@ -24,8 +24,8 @@ msgid "Item"
 msgstr ""
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr "Actions"
 
@@ -35,37 +35,37 @@ msgid "address"
 msgstr ""
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr "All"
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr "Please provide the email adress you used for submitting the order."
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr "No order could be found for the given credentials"
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr "Please provide the ordernumber"
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr "Email"
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr "Ordernumber"
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr "Submit"
 
@@ -179,7 +179,7 @@ msgid "cancelled"
 msgstr "Cancelled"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "City"
 
@@ -208,7 +208,7 @@ msgid "customers_notified_success"
 msgstr "Mail to customers sent"
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Date"
 
@@ -219,13 +219,13 @@ msgstr "Delivery Address:"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr ""
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr "Failed to send Notification to ${receiver}"
 
@@ -250,25 +250,25 @@ msgstr "Failed"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr "Filter for customers"
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr "Filter for vendors"
 
@@ -294,8 +294,8 @@ msgstr "Finished"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "First Name"
 
@@ -353,6 +353,81 @@ msgstr "Using placeholder:"
 msgid "inconsistent_currencies"
 msgstr "Found inconsistent Currencies on order related bookings. This should not happen at all!"
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr "Template Library"
@@ -371,8 +446,8 @@ msgstr "Title"
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Last Name"
 
@@ -418,18 +493,18 @@ msgid "new"
 msgstr "New"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "No"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr "No Payment"
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr "No Shipping"
 
@@ -439,12 +514,12 @@ msgid "no_template_selected"
 msgstr "No template selected"
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "None"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr "Notify customers of selected orders"
 
@@ -493,7 +568,7 @@ msgid "order_discount_vat"
 msgstr "Discount VAT:"
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr "Order Done"
 
@@ -806,62 +881,62 @@ msgid "order_summary"
 msgstr "Order Summary:"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr "Net: ${value} ${currency}"
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr "Total: ${value} ${currency}"
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr "VAT: ${value} ${currency}"
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr "Discount Net: ${value} ${currency}"
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr "Discount Total: ${value} ${currency}"
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr "Discount VAT: ${value} ${currency}"
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr "Summary:"
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr "Shipping: ${label}"
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr "Shipping Net: ${value} ${currency}"
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr "Shipping Total: ${value} ${currency}"
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr "Shipping VAT: ${value} ${currency}"
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr "Thanks for your Order."
 
@@ -926,12 +1001,12 @@ msgid "renew"
 msgstr "Renew"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr "Reservation Done"
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr "Thanks for your Reservation."
 
@@ -942,12 +1017,12 @@ msgstr "Reserved"
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Salaried"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr "Select all visible orders"
 
@@ -957,12 +1032,12 @@ msgstr "send"
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "State"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1030,19 +1105,19 @@ msgid "transaction_id"
 msgstr "Transaction ID:"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "Unknown"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr "Unknown Order"
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr "Sorry, this order does not exist."
 
@@ -1051,25 +1126,35 @@ msgid "vendor_filter"
 msgstr "Vendor"
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr ""
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "View Order"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Yes"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr ""
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/locales/fr/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/fr/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Peter Holzer <hpeter@agitator.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -589,7 +589,7 @@ msgid "order_gender"
 msgstr "Sexe"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -614,22 +614,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -641,17 +641,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -663,47 +663,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -720,7 +725,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -732,17 +737,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -762,27 +767,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -792,17 +797,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/fr/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/fr/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Peter Holzer <hpeter@agitator.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: bda.plone.orders\n"
 "X-Is-Fallback-For: fr-be fr-ca fr-lu fr-mc fr-ch fr-fr\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr ""
 
@@ -25,8 +25,8 @@ msgid "Item"
 msgstr ""
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr ""
 
@@ -36,37 +36,37 @@ msgid "address"
 msgstr ""
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr ""
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr ""
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr ""
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr ""
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr ""
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr ""
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid "cancelled"
 msgstr "Annulé"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "Localité"
 
@@ -209,7 +209,7 @@ msgid "customers_notified_success"
 msgstr ""
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Date"
 
@@ -220,13 +220,13 @@ msgstr "Adresse de livraison"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr ""
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr ""
 
@@ -251,25 +251,25 @@ msgstr "manquer"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr ""
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr ""
 
@@ -295,8 +295,8 @@ msgstr "Terminé"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "Nom"
 
@@ -354,6 +354,81 @@ msgstr ""
 msgid "inconsistent_currencies"
 msgstr "Trouvé sur devises incompatibles de commandes connexes. Cela ne devrait pas se produire du tout!"
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr ""
@@ -372,8 +447,8 @@ msgstr ""
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Nom de famille"
 
@@ -419,18 +494,18 @@ msgid "new"
 msgstr "Nouveau"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "Non"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr ""
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr ""
 
@@ -440,12 +515,12 @@ msgid "no_template_selected"
 msgstr ""
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "Aucun"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr ""
 
@@ -494,7 +569,7 @@ msgid "order_discount_vat"
 msgstr ""
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr ""
 
@@ -807,62 +882,62 @@ msgid "order_summary"
 msgstr "Résumé"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr ""
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr ""
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr ""
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr ""
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr ""
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr ""
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr ""
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr ""
 
@@ -927,12 +1002,12 @@ msgid "renew"
 msgstr "Recommencer"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr ""
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr ""
 
@@ -943,12 +1018,12 @@ msgstr ""
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Payé"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr ""
 
@@ -958,12 +1033,12 @@ msgstr ""
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "Etat"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1031,19 +1106,19 @@ msgid "transaction_id"
 msgstr "ID de transaction"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "Inconnu"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr ""
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr ""
 
@@ -1052,25 +1127,35 @@ msgid "vendor_filter"
 msgstr ""
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr ""
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "Vue de la commande"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Oui"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr ""
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/locales/it/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/it/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: 2013-06-12 14:36+0100\n"
 "Last-Translator: Peter Holzer <peter.holzer@agitator.com>\n"
 "Language-Team: \n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: bda.plone.orders\n"
 "X-Is-Fallback-For: it-ch it-it\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr ""
 
@@ -25,8 +25,8 @@ msgid "Item"
 msgstr ""
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr "Azioni"
 
@@ -36,37 +36,37 @@ msgid "address"
 msgstr ""
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr ""
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr ""
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr ""
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr ""
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr ""
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr ""
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr ""
 
@@ -180,7 +180,7 @@ msgid "cancelled"
 msgstr "Stornato"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "Cittŕ"
 
@@ -209,7 +209,7 @@ msgid "customers_notified_success"
 msgstr ""
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Data"
 
@@ -220,13 +220,13 @@ msgstr "Indirizzo di spedizione"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr ""
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr "Non č stato possibile inviare la notifica a ${receiver}."
 
@@ -251,25 +251,25 @@ msgstr "falllito"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr ""
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr ""
 
@@ -295,8 +295,8 @@ msgstr "Fine"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "Nome"
 
@@ -354,6 +354,81 @@ msgstr ""
 msgid "inconsistent_currencies"
 msgstr "valute incoerenti"
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr ""
@@ -372,8 +447,8 @@ msgstr ""
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Nome"
 
@@ -419,18 +494,18 @@ msgid "new"
 msgstr "Nuovo"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "No"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr ""
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr ""
 
@@ -440,12 +515,12 @@ msgid "no_template_selected"
 msgstr ""
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "Nessuno"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr ""
 
@@ -494,7 +569,7 @@ msgid "order_discount_vat"
 msgstr ""
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr ""
 
@@ -807,62 +882,62 @@ msgid "order_summary"
 msgstr "Riepilogo"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr ""
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr ""
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr ""
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr ""
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr ""
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr ""
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr ""
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr ""
 
@@ -927,12 +1002,12 @@ msgid "renew"
 msgstr "Reimposta"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr ""
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr ""
 
@@ -943,12 +1018,12 @@ msgstr ""
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Pagato:"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr ""
 
@@ -958,12 +1033,12 @@ msgstr ""
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "Stato"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1031,19 +1106,19 @@ msgid "transaction_id"
 msgstr "id transazione"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "sconosciuto"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr ""
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr ""
 
@@ -1052,25 +1127,35 @@ msgid "vendor_filter"
 msgstr ""
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr ""
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "Visualizza ordine"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Sě"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr ""
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/locales/it/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/it/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: 2013-06-12 14:36+0100\n"
 "Last-Translator: Peter Holzer <peter.holzer@agitator.com>\n"
 "Language-Team: \n"
@@ -589,7 +589,7 @@ msgid "order_gender"
 msgstr "Titolo"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -614,22 +614,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -641,17 +641,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -663,47 +663,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -720,7 +725,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -732,17 +737,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -762,27 +767,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -792,17 +797,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/nl/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/nl/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: 2015-01-28 15:13+0100\n"
 "Last-Translator: INTK <info@intk.com>\n"
 "Language-Team: \n"
@@ -590,7 +590,7 @@ msgid "order_gender"
 msgstr "Geslacht:"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -615,22 +615,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -642,17 +642,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -664,47 +664,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -721,7 +726,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -733,17 +738,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -763,27 +768,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -793,17 +798,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/nl/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/nl/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: 2015-01-28 15:13+0100\n"
 "Last-Translator: INTK <info@intk.com>\n"
 "Language-Team: \n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Is-Fallback-For: nl-be nl-nl\n"
 "X-Generator: Poedit 1.7.4\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr ""
 
@@ -26,8 +26,8 @@ msgid "Item"
 msgstr ""
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr "Acties"
 
@@ -37,37 +37,37 @@ msgid "address"
 msgstr ""
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr "Alle"
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr "Geef het e-mailadres op dat u tevens heeft gebruikt voor de bestelling."
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr "Geen bestelling gevonden voor de opgegeven criteria."
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr "Geef het bestelnummer op."
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr "E-mail"
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr "Bestelnummer"
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr "Sturen"
 
@@ -181,7 +181,7 @@ msgid "cancelled"
 msgstr "Gecanceld"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "Stad"
 
@@ -210,7 +210,7 @@ msgid "customers_notified_success"
 msgstr "E-mail naar klanten"
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Datum"
 
@@ -221,13 +221,13 @@ msgstr "Bezorgadres"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr ""
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr "Bericht naar ${receiver} is niet verzonden."
 
@@ -252,25 +252,25 @@ msgstr "Mislukt"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr "Filter voor klanten"
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr "Filter voor verkopers"
 
@@ -296,8 +296,8 @@ msgstr "Afgerond"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "Voornaam"
 
@@ -355,6 +355,81 @@ msgstr "Gebruik placeholder"
 msgid "inconsistent_currencies"
 msgstr "Inconsistente valuta gevonden in bestellingen. Dit mag niet gebeuren!"
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr "Sjablonen bibliotheek"
@@ -373,8 +448,8 @@ msgstr "Titel"
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Achternaam"
 
@@ -420,18 +495,18 @@ msgid "new"
 msgstr "Nieuw"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "Nee"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr "Geen betaalmethode"
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr "Geen verzending"
 
@@ -441,12 +516,12 @@ msgid "no_template_selected"
 msgstr "Geen sjabloon geselecteerd"
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "Geen"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr "Bericht klanten van geselecteerde bestellingen"
 
@@ -495,7 +570,7 @@ msgid "order_discount_vat"
 msgstr "Korting BTW:"
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr "Bestelling afgerond"
 
@@ -808,62 +883,62 @@ msgid "order_summary"
 msgstr "Besteloverzicht:"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr "Netto: ${value} ${currency}"
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr "Totaal: ${value} ${currency}"
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr "BTW: ${value} ${currency}"
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr "Korting netto: ${value} ${currency}"
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr "Totaal korting: ${value} ${currency}"
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr "Korting BTW: ${value} ${currency}"
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr "Overzicht:"
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr "Verzending: ${label}"
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr "Verzending netto: ${value} ${currency}"
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr "Verzending totaal: ${value} ${currency}"
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr "Verzending BTW: ${value} ${currency}"
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr "Bedankt voor uw bestelling."
 
@@ -928,12 +1003,12 @@ msgid "renew"
 msgstr "Verversen"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr "Reservering is voltooid"
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr "Bedankt voor uw reservering."
 
@@ -944,12 +1019,12 @@ msgstr "Gereserveerd"
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Betaald"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr "Selecteer alle zichtbare bestellingen"
 
@@ -959,12 +1034,12 @@ msgstr "Verzenden"
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "Status"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1032,19 +1107,19 @@ msgid "transaction_id"
 msgstr "Transacties ID:"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "Onbekend"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr "Onbekende bestelling"
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr "Excuus, uw bestelling bestaat niet."
 
@@ -1053,25 +1128,35 @@ msgid "vendor_filter"
 msgstr "Verkoper"
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr ""
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "Bekijk bestelling"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Ja"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr ""
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/locales/nn/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/nn/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: 2017-02-06 15:38+0100\n"
 "Last-Translator: Espen Moe-Nilssen <espen@medialog.no>\n"
 "Language-Team: espen@medialog.no\n"
@@ -590,7 +590,7 @@ msgid "order_gender"
 msgstr "Kjønn"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -615,22 +615,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -642,17 +642,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -664,47 +664,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -721,7 +726,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -733,17 +738,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -763,27 +768,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -793,17 +798,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/nn/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/nn/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: 2017-02-06 15:38+0100\n"
 "Last-Translator: Espen Moe-Nilssen <espen@medialog.no>\n"
 "Language-Team: espen@medialog.no\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: nn_NO\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr "Handling avbroten"
 
@@ -26,8 +26,8 @@ msgid "Item"
 msgstr "Produkt"
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr "Handlingar"
 
@@ -37,37 +37,37 @@ msgid "address"
 msgstr "adresse"
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr "alt"
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr ""
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr ""
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr ""
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr ""
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr ""
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr ""
 
@@ -181,7 +181,7 @@ msgid "cancelled"
 msgstr "Avbrutt"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "Postadresse"
 
@@ -210,7 +210,7 @@ msgid "customers_notified_success"
 msgstr ""
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Dato:"
 
@@ -221,13 +221,13 @@ msgstr "Leveringsadresse:"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr "epost"
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr "Epost ti  ${receiver} kunne ikke sendes."
 
@@ -252,25 +252,25 @@ msgstr "Avbrote"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr ""
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr ""
 
@@ -296,8 +296,8 @@ msgstr "Fullført"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "Fornavn"
 
@@ -355,6 +355,81 @@ msgstr ""
 msgid "inconsistent_currencies"
 msgstr "Inkonsekvent valuta for denne ordren. "
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr ""
@@ -373,8 +448,8 @@ msgstr ""
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Etternavn"
 
@@ -420,18 +495,18 @@ msgid "new"
 msgstr "Ny"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "Nei"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr "ikkje betalt"
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr "ikkje sendt"
 
@@ -441,12 +516,12 @@ msgid "no_template_selected"
 msgstr ""
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "Ingen:"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr "kundeinfo"
 
@@ -495,7 +570,7 @@ msgid "order_discount_vat"
 msgstr ""
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr "kjøpt"
 
@@ -808,62 +883,62 @@ msgid "order_summary"
 msgstr "Ordresammendrag:"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr ""
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr ""
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr ""
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr ""
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr ""
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr ""
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr ""
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr "ordre tekst"
 
@@ -928,12 +1003,12 @@ msgid "renew"
 msgstr "Definer som ny"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr "Reservert"
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr "Takkk for din bestilling"
 
@@ -944,12 +1019,12 @@ msgstr "Reservert"
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Betalt"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr "marker alle ordrer"
 
@@ -959,12 +1034,12 @@ msgstr "send"
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "Status"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1032,19 +1107,19 @@ msgid "transaction_id"
 msgstr "Transaksjons ID:"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "Ukjent"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr "ukjent ordre"
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr "ukjent ordre tekst"
 
@@ -1053,25 +1128,35 @@ msgid "vendor_filter"
 msgstr ""
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr "vis bestellingar"
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "Sjekk bestillinger"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr "vis ordrer"
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Ja"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr ""
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/locales/no/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/no/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-11-11 10:57+0000\n"
+"POT-Creation-Date: 2017-11-11 11:24+0000\n"
 "PO-Revision-Date: 2013-08-05 15:25+0100\n"
 "Last-Translator: Espen Moe-Nilssen <espen@medialog.no>\n"
 "Language-Team: <espen@medialog.no>\n"
@@ -590,7 +590,7 @@ msgid "order_gender"
 msgstr "Kjønn"
 
 #. Default: "Address"
-#: ./mailtemplates/order_success.pt:68
+#: ./mailtemplates/order_success.pt:75
 msgid "order_mail_address"
 msgstr ""
 
@@ -615,22 +615,22 @@ msgid "order_mail_cancelled_item"
 msgstr ""
 
 #. Default: "Net"
-#: ./mailtemplates/order_success.pt:240
+#: ./mailtemplates/order_success.pt:247
 msgid "order_mail_cart_net"
 msgstr ""
 
 #. Default: "Total"
-#: ./mailtemplates/order_success.pt:304
+#: ./mailtemplates/order_success.pt:311
 msgid "order_mail_cart_total"
 msgstr ""
 
 #. Default: "VAT"
-#: ./mailtemplates/order_success.pt:245
+#: ./mailtemplates/order_success.pt:252
 msgid "order_mail_cart_vat"
 msgstr ""
 
 #. Default: "City"
-#: ./mailtemplates/order_success.pt:78
+#: ./mailtemplates/order_success.pt:85
 msgid "order_mail_city"
 msgstr ""
 
@@ -642,17 +642,17 @@ msgid "order_mail_click_here"
 msgstr ""
 
 #. Default: "Comment"
-#: ./mailtemplates/order_success.pt:114
+#: ./mailtemplates/order_success.pt:121
 msgid "order_mail_comment"
 msgstr ""
 
 #. Default: "Company"
-#: ./mailtemplates/order_success.pt:57
+#: ./mailtemplates/order_success.pt:64
 msgid "order_mail_company"
 msgstr ""
 
 #. Default: "Country"
-#: ./mailtemplates/order_success.pt:82
+#: ./mailtemplates/order_success.pt:89
 msgid "order_mail_country"
 msgstr ""
 
@@ -664,47 +664,52 @@ msgid "order_mail_date"
 msgstr ""
 
 #. Default: "Delivery Address"
-#: ./mailtemplates/order_success.pt:86
+#: ./mailtemplates/order_success.pt:93
 msgid "order_mail_delivery_address"
 msgstr ""
 
 #. Default: "Discount Net"
-#: ./mailtemplates/order_success.pt:254
+#: ./mailtemplates/order_success.pt:261
 msgid "order_mail_discount_net"
 msgstr ""
 
 #. Default: "Discount Total"
-#: ./mailtemplates/order_success.pt:268
+#: ./mailtemplates/order_success.pt:275
 msgid "order_mail_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT"
-#: ./mailtemplates/order_success.pt:261
+#: ./mailtemplates/order_success.pt:268
 msgid "order_mail_discount_vat"
 msgstr ""
 
 #. Default: "Email"
-#: ./mailtemplates/order_success.pt:65
+#: ./mailtemplates/order_success.pt:72
 msgid "order_mail_email"
 msgstr ""
 
 #. Default: "Name"
-#: ./mailtemplates/order_success.pt:52
+#: ./mailtemplates/order_success.pt:59
 msgid "order_mail_fullname"
 msgstr ""
 
+#. Default: "Invoice"
+#: ./mailtemplates/order_success.pt:50
+msgid "order_mail_invoice"
+msgstr ""
+
 #. Default: "Item Number"
-#: ./mailtemplates/order_success.pt:138
+#: ./mailtemplates/order_success.pt:145
 msgid "order_mail_item_number"
 msgstr ""
 
 #. Default: "Price"
-#: ./mailtemplates/order_success.pt:144
+#: ./mailtemplates/order_success.pt:151
 msgid "order_mail_item_price"
 msgstr ""
 
 #. Default: "Notifications"
-#: ./mailtemplates/order_success.pt:219
+#: ./mailtemplates/order_success.pt:226
 msgid "order_mail_notifications"
 msgstr ""
 
@@ -721,7 +726,7 @@ msgid "order_mail_order_heading"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./mailtemplates/order_success.pt:119
+#: ./mailtemplates/order_success.pt:126
 msgid "order_mail_ordered_items"
 msgstr ""
 
@@ -733,17 +738,17 @@ msgid "order_mail_ordernumber"
 msgstr ""
 
 #. Default: "Payment"
-#: ./mailtemplates/order_success.pt:229
+#: ./mailtemplates/order_success.pt:236
 msgid "order_mail_payment"
 msgstr ""
 
 #. Default: "Personal Data"
-#: ./mailtemplates/order_success.pt:50
+#: ./mailtemplates/order_success.pt:57
 msgid "order_mail_personal_data"
 msgstr ""
 
 #. Default: "Phone"
-#: ./mailtemplates/order_success.pt:61
+#: ./mailtemplates/order_success.pt:68
 msgid "order_mail_phone"
 msgstr ""
 
@@ -763,27 +768,27 @@ msgid "order_mail_reservation_heading"
 msgstr ""
 
 #. Default: "Reserved items"
-#: ./mailtemplates/order_success.pt:169
+#: ./mailtemplates/order_success.pt:176
 msgid "order_mail_reserved_items"
 msgstr ""
 
 #. Default: "Shipping"
-#: ./mailtemplates/order_success.pt:279
+#: ./mailtemplates/order_success.pt:286
 msgid "order_mail_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net"
-#: ./mailtemplates/order_success.pt:284
+#: ./mailtemplates/order_success.pt:291
 msgid "order_mail_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total"
-#: ./mailtemplates/order_success.pt:294
+#: ./mailtemplates/order_success.pt:301
 msgid "order_mail_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT"
-#: ./mailtemplates/order_success.pt:289
+#: ./mailtemplates/order_success.pt:296
 msgid "order_mail_shipping_vat"
 msgstr ""
 
@@ -793,17 +798,17 @@ msgid "order_mail_stock_threshold_reached_heading"
 msgstr ""
 
 #. Default: "Street"
-#: ./mailtemplates/order_success.pt:70
+#: ./mailtemplates/order_success.pt:77
 msgid "order_mail_street"
 msgstr ""
 
 #. Default: "Summary"
-#: ./mailtemplates/order_success.pt:237
+#: ./mailtemplates/order_success.pt:244
 msgid "order_mail_summary"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./mailtemplates/order_success.pt:74
+#: ./mailtemplates/order_success.pt:81
 msgid "order_mail_zip"
 msgstr ""
 

--- a/src/bda/plone/orders/locales/no/LC_MESSAGES/bda.plone.orders.po
+++ b/src/bda/plone/orders/locales/no/LC_MESSAGES/bda.plone.orders.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: bda.plone.orders\n"
-"POT-Creation-Date: 2017-10-22 16:20+0000\n"
+"POT-Creation-Date: 2017-11-11 10:57+0000\n"
 "PO-Revision-Date: 2013-08-05 15:25+0100\n"
 "Last-Translator: Espen Moe-Nilssen <espen@medialog.no>\n"
 "Language-Team: <espen@medialog.no>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: nb_NO\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: ./browser/views.py:1057
+#: ./browser/views.py:928
 msgid "Booking cancelled."
 msgstr ""
 
@@ -26,8 +26,8 @@ msgid "Item"
 msgstr ""
 
 #. Default: "Actions"
-#: ./browser/contacts.py:69
-#: ./browser/views.py:334
+#: ./browser/contacts.py:58
+#: ./browser/views.py:384
 msgid "actions"
 msgstr "Handlinger"
 
@@ -37,37 +37,37 @@ msgid "address"
 msgstr ""
 
 #. Default: "All"
-#: ./browser/views.py:366
+#: ./browser/views.py:416
 msgid "all"
 msgstr ""
 
 #. Default: "Please provide the email adress you used for submitting the order."
-#: ./browser/views.py:962
+#: ./browser/views.py:879
 msgid "anon_auth_err_email"
 msgstr ""
 
 #. Default: "No order could be found for the given credentials"
-#: ./browser/views.py:971
+#: ./browser/views.py:888
 msgid "anon_auth_err_order"
 msgstr ""
 
 #. Default: "Please provide the ordernumber"
-#: ./browser/views.py:967
+#: ./browser/views.py:884
 msgid "anon_auth_err_ordernumber"
 msgstr ""
 
 #. Default: "Email"
-#: ./browser/views.py:927
+#: ./browser/views.py:842
 msgid "anon_auth_label_email"
 msgstr ""
 
 #. Default: "Ordernumber"
-#: ./browser/views.py:918
+#: ./browser/views.py:833
 msgid "anon_auth_label_ordernumber"
 msgstr ""
 
 #. Default: "Submit"
-#: ./browser/views.py:934
+#: ./browser/views.py:849
 msgid "anon_auth_label_submit"
 msgstr ""
 
@@ -181,7 +181,7 @@ msgid "cancelled"
 msgstr "Avbrutt"
 
 #. Default: "City"
-#: ./browser/views.py:352
+#: ./browser/views.py:402
 msgid "city"
 msgstr "Postadresse"
 
@@ -210,7 +210,7 @@ msgid "customers_notified_success"
 msgstr ""
 
 #. Default: "Date"
-#: ./browser/views.py:339
+#: ./browser/views.py:389
 msgid "date"
 msgstr "Dato:"
 
@@ -221,13 +221,13 @@ msgstr "Leveringsadresse:"
 
 #. Default: "Email"
 #: ./browser/bookings.py:368
-#: ./browser/contacts.py:74
-#: ./browser/views.py:349
+#: ./browser/contacts.py:63
+#: ./browser/views.py:399
 msgid "email"
 msgstr ""
 
 #. Default: "Failed to send notification to ${receiver}"
-#: ./mailnotify.py:332
+#: ./mailnotify.py:350
 msgid "email_sending_failed"
 msgstr "Epost ti  ${receiver} kunne ikke sendes."
 
@@ -252,25 +252,25 @@ msgstr "Mislyktes"
 
 #. Default: "Filter for customers"
 #: ./browser/bookings.py:174
-#: ./browser/views.py:413
+#: ./browser/views.py:463
 msgid "filter_for_customers"
 msgstr ""
 
 #. Default: "Filter for salaried state"
 #: ./browser/bookings.py:200
-#: ./browser/views.py:437
+#: ./browser/views.py:487
 msgid "filter_for_salaried"
 msgstr ""
 
 #. Default: "Filter for states"
 #: ./browser/bookings.py:187
-#: ./browser/views.py:425
+#: ./browser/views.py:475
 msgid "filter_for_state"
 msgstr ""
 
 #. Default: "Filter for vendors"
 #: ./browser/bookings.py:157
-#: ./browser/views.py:398
+#: ./browser/views.py:448
 msgid "filter_for_vendors"
 msgstr ""
 
@@ -296,8 +296,8 @@ msgstr "Fullført"
 
 #. Default: "First Name"
 #: ./browser/bookings.py:418
-#: ./browser/contacts.py:82
-#: ./browser/views.py:346
+#: ./browser/contacts.py:71
+#: ./browser/views.py:396
 msgid "firstname"
 msgstr "Fornavn"
 
@@ -355,6 +355,81 @@ msgstr ""
 msgid "inconsistent_currencies"
 msgstr "Inkonsekvent valuta for denne ordren. Vennligst sjekk flyt av varer og penger!"
 
+#. Default: "Invoice"
+#: ./browser/invoice.pt:66
+msgid "invoice"
+msgstr ""
+
+#. Default: "Net"
+#: ./browser/invoice.pt:128
+msgid "invoice_cart_net"
+msgstr ""
+
+#. Default: "Total"
+#: ./browser/invoice.pt:230
+msgid "invoice_cart_total"
+msgstr ""
+
+#. Default: "VAT"
+#: ./browser/invoice.pt:138
+msgid "invoice_cart_vat"
+msgstr ""
+
+#. Default: "Discount Net"
+#: ./browser/invoice.pt:153
+msgid "invoice_discount_net"
+msgstr ""
+
+#. Default: "Discount Total"
+#: ./browser/invoice.pt:177
+msgid "invoice_discount_total"
+msgstr ""
+
+#. Default: "Discount VAT"
+#: ./browser/invoice.pt:165
+msgid "invoice_discount_vat"
+msgstr ""
+
+#. Default: "Kind regards"
+#: ./browser/invoice.pt:259
+msgid "invoice_kind_regards"
+msgstr ""
+
+#. Default: "Amount"
+#: ./browser/invoice.pt:78
+msgid "invoice_listing_amount"
+msgstr ""
+
+#. Default: "Position"
+#: ./browser/invoice.pt:81
+msgid "invoice_listing_position"
+msgstr ""
+
+#. Default: "Price"
+#: ./browser/invoice.pt:84
+msgid "invoice_listing_price"
+msgstr ""
+
+#. Default: "All prices in"
+#: ./browser/invoice.pt:254
+msgid "invoice_prices_in_currency"
+msgstr ""
+
+#. Default: "Shipping Net"
+#: ./browser/invoice.pt:194
+msgid "invoice_shipping_net"
+msgstr ""
+
+#. Default: "Shipping Total"
+#: ./browser/invoice.pt:214
+msgid "invoice_shipping_total"
+msgstr ""
+
+#. Default: "Shipping VAT"
+#: ./browser/invoice.pt:204
+msgid "invoice_shipping_vat"
+msgstr ""
+
 # label_mailtemplatelib_array
 msgid "label_mailtemplatelib_array"
 msgstr ""
@@ -373,8 +448,8 @@ msgstr ""
 
 #. Default: "Last Name"
 #: ./browser/bookings.py:419
-#: ./browser/contacts.py:78
-#: ./browser/views.py:343
+#: ./browser/contacts.py:67
+#: ./browser/views.py:393
 msgid "lastname"
 msgstr "Etternavn"
 
@@ -420,18 +495,18 @@ msgid "new"
 msgstr "Ny"
 
 #. Default: "No"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:40
 msgid "no"
 msgstr "Nei"
 
 #. Default: "No Payment"
-#: ./common.py:305
+#: ./common.py:306
 msgid "no_payment"
 msgstr ""
 
 #. Default: "No Shipping"
-#: ./common.py:330
+#: ./common.py:331
 msgid "no_shipping"
 msgstr ""
 
@@ -441,12 +516,12 @@ msgid "no_template_selected"
 msgstr ""
 
 #. Default: "None"
-#: ./browser/views.py:819
+#: ./browser/views.py:1082
 msgid "none"
 msgstr "Ingen:"
 
 #. Default: "Notify customers of selected orders"
-#: ./browser/views.py:469
+#: ./browser/views.py:519
 msgid "notify_customers"
 msgstr ""
 
@@ -495,7 +570,7 @@ msgid "order_discount_vat"
 msgstr ""
 
 #. Default: "Order Done"
-#: ./browser/views.py:1014
+#: ./browser/views.py:1275
 msgid "order_done"
 msgstr ""
 
@@ -808,62 +883,62 @@ msgid "order_summary"
 msgstr "Ordresammendrag:"
 
 #. Default: "Net: ${value} ${currency}"
-#: ./mailnotify.py:444
+#: ./mailnotify.py:462
 msgid "order_summary_cart_net"
 msgstr ""
 
 #. Default: "Total: ${value} ${currency}"
-#: ./mailnotify.py:523
+#: ./mailnotify.py:541
 msgid "order_summary_cart_total"
 msgstr ""
 
 #. Default: "VAT: ${value} ${currency}"
-#: ./mailnotify.py:452
+#: ./mailnotify.py:470
 msgid "order_summary_cart_vat"
 msgstr ""
 
 #. Default: "Discount Net: ${value} ${currency}"
-#: ./mailnotify.py:462
+#: ./mailnotify.py:480
 msgid "order_summary_discount_net"
 msgstr ""
 
 #. Default: "Discount Total: ${value} ${currency}"
-#: ./mailnotify.py:478
+#: ./mailnotify.py:496
 msgid "order_summary_discount_total"
 msgstr ""
 
 #. Default: "Discount VAT: ${value} ${currency}"
-#: ./mailnotify.py:470
+#: ./mailnotify.py:488
 msgid "order_summary_discount_vat"
 msgstr ""
 
 #. Default: "Summary:"
-#: ./mailnotify.py:531
+#: ./mailnotify.py:549
 msgid "order_summary_label"
 msgstr ""
 
 #. Default: "Shipping: ${label}"
-#: ./mailnotify.py:488
+#: ./mailnotify.py:506
 msgid "order_summary_shipping_label"
 msgstr ""
 
 #. Default: "Shipping Net: ${value} ${currency}"
-#: ./mailnotify.py:499
+#: ./mailnotify.py:517
 msgid "order_summary_shipping_net"
 msgstr ""
 
 #. Default: "Shipping Total: ${value} ${currency}"
-#: ./mailnotify.py:515
+#: ./mailnotify.py:533
 msgid "order_summary_shipping_total"
 msgstr ""
 
 #. Default: "Shipping VAT: ${value} ${currency}"
-#: ./mailnotify.py:507
+#: ./mailnotify.py:525
 msgid "order_summary_shipping_vat"
 msgstr ""
 
 #. Default: "Thanks for your Order."
-#: ./browser/views.py:1031
+#: ./browser/views.py:1292
 msgid "order_text"
 msgstr ""
 
@@ -928,12 +1003,12 @@ msgid "renew"
 msgstr "Definer som ny"
 
 #. Default: "Reservation Done"
-#: ./browser/views.py:1013
+#: ./browser/views.py:1274
 msgid "reservation_done"
 msgstr "Reservert"
 
 #. Default: "Thanks for your Reservation."
-#: ./browser/views.py:1029
+#: ./browser/views.py:1290
 msgid "reservation_text"
 msgstr "Takkk for din bestilling"
 
@@ -944,12 +1019,12 @@ msgstr "Reservert"
 
 #. Default: "Salaried"
 #: ./browser/bookings.py:465
-#: ./browser/views.py:355
+#: ./browser/views.py:405
 msgid "salaried"
 msgstr "Betalt"
 
 #. Default: "Select all visible orders"
-#: ./browser/views.py:460
+#: ./browser/views.py:510
 msgid "select_all_orders"
 msgstr ""
 
@@ -959,12 +1034,12 @@ msgstr ""
 
 #. Default: "State"
 #: ./browser/bookings.py:471
-#: ./browser/views.py:359
+#: ./browser/views.py:409
 msgid "state"
 msgstr "Status"
 
 #. Default: "Cannot show order information because no order uid was given."
-#: ./browser/views.py:689
+#: ./browser/views.py:787
 msgid "statusmessage_err_no_order_uid_given"
 msgstr ""
 
@@ -1032,19 +1107,19 @@ msgid "transaction_id"
 msgstr "Transaksjons ID:"
 
 #. Default: "Unknown"
-#: ./browser/views.py:829
-#: ./common.py:301
+#: ./browser/views.py:1092
+#: ./common.py:302
 #: ./upgrades.py:227
 msgid "unknown"
 msgstr "Ukjent"
 
 #. Default: "Unknown Order"
-#: ./browser/views.py:1016
+#: ./browser/views.py:1277
 msgid "unknown_order"
 msgstr ""
 
 #. Default: "Sorry, this order does not exist."
-#: ./browser/views.py:1033
+#: ./browser/views.py:1294
 msgid "unknown_order_text"
 msgstr ""
 
@@ -1053,25 +1128,35 @@ msgid "vendor_filter"
 msgstr ""
 
 #. Default: "View Bookings"
-#: ./browser/contacts.py:54
+#: ./browser/contacts.py:43
 msgid "view_bookings"
 msgstr ""
 
+#. Default: "View Invoice"
+#: ./browser/views.py:556
+msgid "view_invoice"
+msgstr ""
+
 #. Default: "View Order"
-#: ./browser/views.py:493
+#: ./browser/views.py:545
 msgid "view_order"
 msgstr "Sjekk bestillinger"
 
 #. Default: "View Orders"
-#: ./browser/contacts.py:43
+#: ./browser/contacts.py:32
 msgid "view_orders"
 msgstr ""
 
 #. Default: "Yes"
-#: ./browser/views.py:836
+#: ./browser/views.py:1099
 #: ./vocabularies.py:39
 msgid "yes"
 msgstr "Ja"
+
+#. Default: "Your Invoice"
+#: ./browser/invoice.pt:10
+msgid "your_invoice"
+msgstr ""
 
 #. Default: "Your Order number"
 #: ./browser/order_done.pt:24

--- a/src/bda/plone/orders/mailtemplates.py
+++ b/src/bda/plone/orders/mailtemplates.py
@@ -24,6 +24,8 @@ Thank you for your order:
 Ordernumber: %(ordernumber)s
 Order details: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 
+Invoice: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
+
 Personal Data:
 Name: %(personal_data.firstname)s %(personal_data.lastname)s
 Company: %(personal_data.company)s
@@ -54,6 +56,8 @@ Thank you for your reservation:
 
 Ordernumber: %(ordernumber)s
 Reservation details: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
+
+Invoice: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
 
 Personal Data:
 Name: %(personal_data.firstname)s %(personal_data.lastname)s
@@ -138,6 +142,8 @@ Besten Dank für Ihre Bestellung:
 Bestellnummer: %(ordernumber)s
 Details zur Bestellung: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 
+Rechnung: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
+
 Persönliche Angaben:
 Name: %(personal_data.firstname)s %(personal_data.lastname)s
 Firma: %(personal_data.company)s
@@ -166,6 +172,8 @@ Besten Dank für Ihre Reservierung:
 
 Bestellnummer: %(ordernumber)s
 Details zur Reservierung: %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
+
+Rechnung: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
 
 Persönliche Angaben:
 Name: %(personal_data.firstname)s %(personal_data.lastname)s
@@ -241,6 +249,8 @@ Nous vous remercions pour votre commande:
 No. de commande: %(ordernumber)s
 %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 
+Le calcul: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
+
 Données personnelles:
 Nom: %(personal_data.firstname)s %(personal_data.lastname)s
 Entreprise: %(personal_data.company)s
@@ -269,6 +279,8 @@ Nous vous remercions pour votre réservation:
 
 No. de commande: %(ordernumber)s
 %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
+
+Le calcul: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
 
 Données personnelles:
 Nom: %(personal_data.firstname)s %(personal_data.lastname)s
@@ -331,6 +343,8 @@ Grazie per l'ordine effettuato:
 Numero d'ordine: %(ordernumber)s
 %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 
+La fattura: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
+
 Dati personali:
 Nome: %(personal_data.firstname)s %(personal_data.lastname)s
 Ditta: %(personal_data.company)s
@@ -358,6 +372,8 @@ Grazie per l'prenotazione effettuato:
 
 Numero d'ordine: %(ordernumber)s
 %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
+
+La fattura: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
 
 Dati personali:
 Nome: %(personal_data.firstname)s %(personal_data.lastname)s
@@ -419,6 +435,8 @@ Takk for din bestilling:
 Ordernummer: %(ordernumber)s
 %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
 
+Regning: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
+
 Personlig info:
 Navn: %(personal_data.firstname)s %(personal_data.lastname)s
 Firma: %(personal_data.company)s
@@ -447,6 +465,8 @@ Takk for din bestilling:
 
 Ordernummer: %(ordernumber)s
 %(portal_url)s/@@showorder?ordernumber=%(ordernumber)s
+
+Regning: %(portal_url)s/@@showinvoice?ordernumber=%(ordernumber)s
 
 Personlig info:
 Navn: %(personal_data.firstname)s %(personal_data.lastname)s

--- a/src/bda/plone/orders/mailtemplates/order_success.pt
+++ b/src/bda/plone/orders/mailtemplates/order_success.pt
@@ -47,6 +47,13 @@
     </a>
     <br />
 
+    <strong i18n:translate="order_mail_invoice">Invoice</strong>:
+    <a href="${order['portal_url'] + '/@@showinvoice?ordernumber=' + order['ordernumber']}"
+       i18n:translate="order_mail_click_here">
+      Click here
+    </a>
+    <br />
+
     <h2 i18n:translate="order_mail_personal_data">Personal Data</h2>
 
     <strong i18n:translate="order_mail_fullname">Name</strong>:


### PR DESCRIPTION
This PR includes the following changes:

- Ajaxify cancel bookings.

- Fix comment editing in plone 5.

- Only display cancel booking action if booking not already cancelled.

- Fix error in the order detail if the product no longer exists (#20).

- Do not exclude reserved bookings by default from billing. This resolves
  inconsistenty introduced with
  https://github.com/bluedynamics/bda.plone.orders/pull/39 and addressed at
  https://github.com/bluedynamics/bda.plone.orders/issues/45.

- Introduce ``ProtectedOrderDataView`` and use as base for ``DirectOrderView``
  and ``DirectInvoiceView``.

- Add invoice view.

- Remove duplicate ``Translate`` class from
  ``bda.plone.orders.browser.contacts``.

- Rename ``OrdersContentView`` to ``ContentViewBase``. Provide B/C alias.
  Introduce view configuration properties ``do_disable_border``,
  ``do_disable_left_column`` and ``do_disable_right_column``.

- Introduce ``OrderDataView`` base class for views dealing with single order
  data.
